### PR TITLE
Fix download links for nightly builds (stable and maintenance)

### DIFF
--- a/_layouts/nightly.html
+++ b/_layouts/nightly.html
@@ -43,7 +43,7 @@
                     <img src="/img/dl-binary.png" class="img-responsive"></img>
                   </div>
                   <div class="col-xs-10">
-                     <a href="{{site.nightly_url}}/{{page.branch}}/geoserver-master-latest-bin.zip">Platform Independent Binary</a>
+                     <a href="{{site.nightly_url}}/{{page.branch}}/geoserver-{{page.branch}}-latest-bin.zip">Platform Independent Binary</a>
                     <p>
                       Operating system independent runnable binary.
                     </p>
@@ -56,7 +56,7 @@
                     <img src="/img/dl-war.png" class="img-responsive"></img>
                   </div>
                   <div class="col-xs-10">
-                    <a href="{{site.nightly_url}}/{{page.branch}}/geoserver-master-latest-war.zip">Web Archive</a>
+                    <a href="{{site.nightly_url}}/{{page.branch}}/geoserver-{{page.branch}}-latest-war.zip">Web Archive</a>
                     <p>
                       Web Archive (war) for servlet containers.
                     </p>


### PR DESCRIPTION
Prior to this change, they point to (for stable):
http://ares.boundlessgeo.com/geoserver/2.7.x/geoserver-master-latest-bin.zip
and
http://ares.boundlessgeo.com/geoserver/2.7.x/geoserver-master-latest-war.zip

However we need:
http://ares.boundlessgeo.com/geoserver/2.7.x/geoserver-2.7.x-latest-bin.zip
and
http://ares.boundlessgeo.com/geoserver/2.7.x/geoserver-2.7.x-latest-war.zip