### PR TITLE
Fix nightly download page.

### DIFF
--- a/_layouts/nightly.html
+++ b/_layouts/nightly.html
@@ -152,7 +152,7 @@
                 <ul>
                   <li><a dl="excel-plugin">Excel</a></li>
                   <li><a dl="imagemap-plugin">Image Map</a></li>
-                  <li><a dl="ogr-plugin">OGR</a></li>
+                  <li>OGR (<a dl="ogr-wfs-plugin">WFS</a>, <a dl="ogr-wps-plugin">WPS</a>)</li>
                   <li><a dl="xslt-plugin">XSLT</a></li>
                   <li><a dl="dxf-plugin">DXF</a></li>
                   <li><a dl="libjpeg-turbo-plugin">JPEG Turbo</a></li>
@@ -162,9 +162,9 @@
                 <h4>Services</h4>
                 <ul>
                   <li><a dl="csw-plugin">CSW</a></li>
-                  <li><a dl="wcs-plugin">WCS 2.0</a></li>
                   <li><a dl="wcs2_0-eo-plugin">WCS 2.0 EO</a></li>
                   <li><a dl="wps-plugin">WPS</a></li>
+                  <li><a dl="wps-cluster-hazelcast-plugin">WPS Hazelcast</a></li>
                 </ul>
               </div>             
             </div>


### PR DESCRIPTION
Removes WCS 2.0 extension, adds WPS Hazelcast.

Fixes OGR download links (perhaps not ideally placed, but at least working)