### PR TITLE
Update the download links on the download page + archived 2.9 links

### DIFF
--- a/download/index.html
+++ b/download/index.html
@@ -108,19 +108,13 @@ function init() {
           <p>
             The recommended release of GeoServer, <br/> tested and supported by the community.
           </p>
-          GeoServer 2.10 releases:
+          GeoServer 2.11 releases:
           <ul class="list-unstyled">
             <li>
               <ul class="list-inline">
-              <li><a href="/release/2.10.3">2.10.3</a></li>
-              <li><a href="/release/2.10.2">2.10.2</a></li>
-                <li><a href="/release/2.10.1">2.10.1</a></li>
-                <li><a href="/release/2.10.0">2.10.0</a></li>
-              </ul>
-              <ul class="list-inline">
-                <li><a href="/release/2.10-RC1">2.10-RC1</a></li>
-                <li><a href="/release/2.10-beta">2.10-beta</a></li>
-                <li><a href="/release/2.10-M0">2.10-M0</a></li>
+                <li><a href="/release/2.11.0">2.11.0</a></li>
+                <li><a href="/release/2.11-RC1">2.11-RC1</a></li>
+                <li><a href="/release/2.11-beta">2.11-beta</a></li>
               </ul>
             </li>
           </ul>
@@ -137,21 +131,19 @@ function init() {
           <p>
             Long term support, <br/>so you have time to upgrade.
           </p>
-            GeoServer 2.9 releases:
+            GeoServer 2.10 releases:
             <ul class="list-unstyled">
               <li>
                 <ul class="list-inline">
-                  <li><a href="/release/2.9.4">2.9.4</a></li>
-                  <li><a href="/release/2.9.3">2.9.3</a></li>
-                  <li><a href="/release/2.9.2">2.9.2</a></li>
-                  <li><a href="/release/2.9.1">2.9.1</a></li>
-                  <li><a href="/release/2.9.0">2.9.0</a></li>
-                  <li><a href="/release/2.9-RC1">2.9-RC1</a></li>
+                  <li><a href="/release/2.10.3">2.10.3</a></li>
+                  <li><a href="/release/2.10.2">2.10.2</a></li>
+                  <li><a href="/release/2.10.1">2.10.1</a></li>
+                  <li><a href="/release/2.10.0">2.10.0</a></li>
                 </ul>
                 <ul class="list-inline">
-                  <li><a href="/release/2.9-beta2">2.9-beta2</a></li>
-                  <li><a href="/release/2.9-beta">2.9-beta</a></li>
-                  <li><a href="/release/2.9-M0">2.9-M0</a></li>
+                  <li><a href="/release/2.10-RC1">2.10-RC1</a></li>
+                  <li><a href="/release/2.10-beta">2.10-beta</a></li>
+                  <li><a href="/release/2.10-M0">2.10-M0</a></li>
                 </ul>
               </li>
             </ul>
@@ -218,6 +210,26 @@ function init() {
       <div class="row">
         <div class="col-md-12 download-archive">
           <h4>Archived</h4>
+          <h3>GeoServer 2.9.x</h3>
+          <p>
+          GeoServer 2.9.x archives, compatible with Java 8.
+          </p>
+          <ul class="list-unstyled">
+            <li>
+              <ul class="list-inline">
+                <li><a href="/release/2.9.4">2.9.4</a></li>
+                <li><a href="/release/2.9.3">2.9.3</a></li>
+                <li><a href="/release/2.9.2">2.9.2</a></li>
+                <li><a href="/release/2.9.1">2.9.1</a></li>
+                <li><a href="/release/2.9.0">2.9.0</a></li>
+              </ul>
+              <ul class="list-inline">
+                <li><a href="/release/2.9-RC1">2.9-RC1</a></li>
+                <li><a href="/release/2.9-beta">2.9-beta</a></li>
+                <li><a href="/release/2.9-beta2">2.9-beta2</a></li>
+              </ul>
+            </li>
+          </ul>
           <h3>GeoServer 2.8.x</h3>
           <p>
           GeoServer 2.8.x archives, compatible with Java 8.


### PR DESCRIPTION
Noticed that the 2.9 download links were missing from the archive page, and the main download links pointed to the previous stable/maintenance releases.