### PR TITLE
Move terrestris to 'Experienced Providers' section

### DIFF
--- a/support/index.html
+++ b/support/index.html
@@ -133,7 +133,16 @@ id: support
           </p>
         </div>
     </div>
-    
+
+    <div class="row tbl">
+        <div class="col-xs-2 cell text-center">
+           <img src="img/terrestris-logo.png"></img>
+        </div>
+        <div class="col-xs-10">
+           <a href="https://www.terrestris.de/en/">terrestris</a> is a spatial service provider that uses GeoServer as one of the columns of their Open Source WebGIS-framework SHOGun focussed on WMS, WMTS, WFS-T and WPS. Around this framework terrestris offers consulting, customized project development, training, maintenance and support for all components of the complete Open Source software stack. terrestris has introduced and is accompanying and supporting many Geoserver installations in large industries and public administrations mainly in Germany. terrestris is also business partner of both major GeoServer-contributing companies Boundless and GeoSolutions.
+        </div>
+    </div>
+
 </section>
 
 <section id="additional">
@@ -163,14 +172,6 @@ id: support
         </div>
         <div class="col-xs-10">
             <a href="http://www.envitia.com/">Envitia</a> supplies geospatial software solutions for mission critical systems within government and defense. Envitia helps organizations to make use of geospatial intelligence in critical operational environments through an open systems approach and complements its high performance, specialist software with open source products. Envitia is at the forefront of development and support of open source software, including GeoNetworks, Quantum GIS and the OpenGeo Suite. Envitia have supplemented our expertise in this area with a partnership with OpenGeo.
-        </div>
-    </div>
-    <div class="row tbl">
-        <div class="col-xs-2 cell text-center">
-           <img src="img/terrestris-logo.png"></img>
-        </div>
-        <div class="col-xs-10">
-           <a href="http://www.terrestris.de/en/">terrestris</a> is a spatial service provider that uses GeoServer as one of the columns of their Open Source WebGIS-framework SHOGun focussed on WMS, WMTS, WFS-T and WPS. Around this framework terrestris offers consulting, customized project development, training, maintenance and support for all components of the complete Open Source software stack. terrestris has introduced and is accompanying and supporting many Geoserver installations in large industries and public administrations mainly in Germany. terrestris is also business partner of both major GeoServer-contributing companies Boundless and Geosolutions.
         </div>
     </div>
 </section>


### PR DESCRIPTION
We, the company of terrestris, herewith apply for being listed as "trusted as reliable organization with experience around GeoServer" in the above mentioned section. Around GeoServer, we @terrestris:
- performed workshops on GeoServer with Geosolutions and on our own (fossgis, customers)
- run and operate several GeoServer installations, also for big customers such as telecommunication providers and federal agencies especially in Germany
- sent 2 people to the boundless "train the trainer" training two years ago
- assigned several orders to Geosolutions for enhancement of GeoServer
- have at least 2 devs close to GeoServer-code (one is Andreas Schmitz, one of the former core dev's of deegree)
- ...

Having done all this and using GeoServer in more or less all of our projects, we feel more than confident in being able to deliver at least the same services than the other listed companies in that section.