### PR TITLE
Remove map from homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,10 +84,10 @@ Designed for interoperability, it publishes data from any major spatial data sou
 
 <section id="">
   <div class="row">
-    <div class="col-md-6">
+    <!--div class="col-md-6">
       <div id="map" class="map"></div>
-    </div>
-    <div class="col-md-6">
+    </div-->
+    <div class="col-md-12">
       <div id="download">
         <h2><a href="/download">Download</a> <span class="glyphicon glyphicon-download"></span></h2>
         <div class="row">


### PR DESCRIPTION
This PR removes temporarily the map from homepage because layers aren't visible.

preview:
![homepage-geoserver](https://user-images.githubusercontent.com/19175505/53963943-93f1c400-40ee-11e9-8445-b3a3e625320e.png)
