### PR TITLE
Master should now be 2.19

### DIFF
--- a/release/master/index.html
+++ b/release/master/index.html
@@ -6,5 +6,5 @@ jira_version: 16798
 branch_name:  master
 docs:  latest
 branch: master
-series: '2.18'
+series: '2.19'
 ---


### PR DESCRIPTION
Should fix links at http://geoserver.org/release/master/ that point to 2.18 and break.