### PR TITLE
Remove duplicate HTML id-attribute

### DIFF
--- a/support/index.html
+++ b/support/index.html
@@ -25,7 +25,7 @@ id: support
     GeoServer community that offer commercial support.
 </p>
 
-<section id="core">
+<section id="support-for-open-source">
     <h2>Support for Open Source</h2>
     <p>
         One inaccurate myth about Open Source is the idea that you can't get high quality


### PR DESCRIPTION
This PR suggests to change the id attribute of a section in the "Support - GeoServer" page; previously the id `core` was used twice on the page:

![image](https://user-images.githubusercontent.com/227934/107157750-345d5c80-6986-11eb-86df-8cb3675a0065.png)

This change does not result in any visible change that I could notice, but duplicated `id`s are generally [not recommended](https://www.w3.org/TR/WCAG20-TECHS/H93.html).

Please review.