### PR TITLE
Move terrestris to experienced provider section

### DIFF
--- a/support/index.html
+++ b/support/index.html
@@ -125,6 +125,24 @@ id: support
           </p>
         </div>
     </div>
+
+    <div class="row tbl">
+        <div class="col-xs-2 cell text-center">
+           <img src="img/terrestris-logo.png"></img>
+        </div>
+        <div class="col-xs-10">
+           <a href="http://www.terrestris.de/en/">terrestris</a> provides
+           top-notch Free and OpenSource GIS services, solutions and training
+           from Bonn, Germany. We offer custom project solutions, connect you
+           with communities and provide general support for many FOSS packages
+           and libraries. We help our customers in the planning, implementation
+           &amp; maintenance of their spatial data infrastructures (SDI) with
+           FOSS. GeoServer is often one crucial pillar in such SDIs; please
+           <a href="mailto:info@terrestris.de" title="Send terrestris an email">reach
+           out</a>, to see if we can help you to get the best out of FOSS for
+           geospatial.
+        </div>
+    </div>
     
 </section>
 
@@ -149,15 +167,7 @@ id: support
             <a href="http://www.alkante.com/">Alkante</a> company is one of the French leaders in geoInformatics, it is specialized in Geographic Information Systems (GIS). Alkante's double core business consists in GIS technologies consulting and GIS solutions development and integration. In particular, Alkante develops applications making data capture, treatment and geographic data diffusion easier.
         </div>
     </div>
-    
-    <div class="row tbl">
-        <div class="col-xs-2 cell text-center">
-           <img src="img/terrestris-logo.png"></img>
-        </div>
-        <div class="col-xs-10">
-           <a href="http://www.terrestris.de/en/">terrestris</a> is a spatial service provider that uses GeoServer as one of the columns of their Open Source WebGIS-framework SHOGun focussed on WMS, WMTS, WFS-T and WPS. Around this framework terrestris offers consulting, customized project development, training, maintenance and support for all components of the complete Open Source software stack. terrestris has introduced and is accompanying and supporting many GeoServer installations in large industries and public administrations mainly in Germany. terrestris is also business partner of both major GeoServer-contributing companies Planet Federal and GeoSolutions.
-        </div>
-    </div>
+
     <div class="row tbl">
         <div class="col-xs-2 cell text-center">
             <img src="img/nrgs-logo.png" width="52" height="52"></img>

--- a/support/index.html
+++ b/support/index.html
@@ -110,7 +110,7 @@ id: support
             <img src="img/wheregroup-logo.png"></img>
         </div>
         <div class="col-xs-10">
-            <a href="http://www.wheregroup.com/">The Where Group</a> (Germany), has worked extensively with GeoServer installations, integrating GeoServer through WMS and WFS-T with the Open Source <a href="http://www.mapbender.org/">Mapbender</a> client. They are the recommended GeoServer provider for Germany, for installations, training and consultation services. See their <a href="http://www.wheregroup.com/en/webgis">Consultation Page</a> for more information.
+            <a href="http://www.wheregroup.com/">The Where Group</a> (Germany), has worked extensively with GeoServer installations, integrating GeoServer through WMS and WFS-T with the Open Source <a href="http://www.mapbender.org/">Mapbender</a> client. They are a recommended GeoServer provider for Germany, for installations, training and consultation services. See their <a href="http://www.wheregroup.com/en/webgis">Consultation Page</a> for more information.
         </div>
     </div>
     

--- a/support/index.html
+++ b/support/index.html
@@ -133,13 +133,13 @@ id: support
         <div class="col-xs-10">
            <a href="http://www.terrestris.de/en/">terrestris</a> provides
            top-notch Free and OpenSource GIS services, solutions and training
-           from Bonn, Germany. We offer custom project solutions, connect you
+           from Bonn, Germany. Offering custom project solutions, connecting you
            with communities and provide general support for many FOSS packages
-           and libraries. We help our customers in the planning, implementation
+           and libraries. They help customers in the planning, implementation
            &amp; maintenance of their spatial data infrastructures (SDI) with
            FOSS. GeoServer is often one crucial pillar in such SDIs; please
            <a href="mailto:info@terrestris.de" title="Send terrestris an email">reach
-           out</a>, to see if we can help you to get the best out of FOSS for
+           out</a>, to see if terrestris can help you to get the best out of FOSS for
            geospatial.
         </div>
     </div>


### PR DESCRIPTION
This PR suggests to move terrestris to the "experienced providers" section. Discussion happens on the [devel-mailinglist](http://osgeo-org.1560.x6.nabble.com/Commercial-support-requirements-to-move-terrestris-to-experienced-providers-td5456143.html).

This PR contains two commits, [one](https://github.com/geoserver/geoserver.github.io/commit/993f8aead2264b9e4314a02b5e24dc64b583fd44) that moves terrestris to the experienced providers section (also the short info is being rephrased), and [another one](https://github.com/geoserver/geoserver.github.io/commit/5ff7cbb368a681dba0f069bcae8ef688d5f2d679), which contains a tiny change to the WhereGroup info-text. ("…They are **a** recommended GeoServer provider for Germany` instead of `…They are **the** recommended GeoServer provider for Germany`). I really hope this is OK, if not this commit can easily be removed. I'll notify two of my contacts to this company, so they might weigh in here.

I would be happy to have this in, but the discussions on the mailinglist are still ongoing.