### PR TITLE
fix maintaince release version of download page

### DIFF
--- a/download/index.html
+++ b/download/index.html
@@ -141,7 +141,7 @@ function init() {
             for six-months of minor updates, for bug fixes.
           </p>
           <p>
-            GeoServer 2.18 maintenance release:
+            GeoServer {{site.maintain_branch | remove: '.x'}} maintenance release:
             <ul class="list-unstyled">
               <li>
                 <ul class="list-inline">


### PR DESCRIPTION
The maintaince version in the download page remains literal, this pr simply makes it to a variable.