### PR TITLE
[GEOS-9503] Create CNAME for geoserver.org

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+geoserver.org


### PR DESCRIPTION
I think we're missing a CNAME file, see also: https://osgeo-org.atlassian.net/browse/GEOS-9503