### PR TITLE
Revert "Add temporary message on doc website unavailability"

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,9 +63,6 @@ function init() {
 <p class="lead">
 Designed for interoperability, it publishes data from any major spatial data source using open standards.  
 </p>
-<p>
-The GeoServer documentation website is currently unavailable for maintenance reasons. You can still download the documentation on the download page.
-</p>
 </div>
 
 <section id="">


### PR DESCRIPTION
Reverts geoserver/geoserver.github.io#118

docs.geoserver.org is back online.