### PR TITLE
mark releases with security considerations in vulnerability category

### DIFF
--- a/_posts/2015-08-31-geoserver-2-8-beta-release.md
+++ b/_posts/2015-08-31-geoserver-2-8-beta-release.md
@@ -9,6 +9,7 @@ title: GeoServer 2.8-beta released
 wordpress_id: 2292
 categories:
 - Announcements
+- Vulnerability
 ---
 
 We are happy to announce the release of [GeoServer 2.8-beta](http://geoserver.org/release/2.8-beta/). Downloads are available ([zip](http://sourceforge.net/projects/geoserver/files/GeoServer/2.8-beta/geoserver-2.8-beta-bin.zip/download), [war](http://sourceforge.net/projects/geoserver/files/GeoServer/2.8-beta/geoserver-2.8-beta-war.zip/download), [dmg](http://sourceforge.net/projects/geoserver/files/GeoServer/2.8-beta/geoserver-2.8-beta.dmg/download) and [exe](http://sourceforge.net/projects/geoserver/files/GeoServer/2.8-beta/geoserver-2.8-beta.exe/download)) along with docs and extensions.

--- a/_posts/2016-08-05-geoserver-2-9-1-released.md
+++ b/_posts/2016-08-05-geoserver-2-9-1-released.md
@@ -7,6 +7,9 @@ link: http://blog.geoserver.org/2016/08/05/geoserver-2-9-1-released/
 slug: geoserver-2-9-1-released
 title: GeoServer 2.9.1 Released
 wordpress_id: 2689
+categories:
+- Announcements
+- Vulnerability
 ---
 
 The GeoServer team is pleased to announce the release of GeoServer 2.9.1. Download bundles are provided ([bin](https://sourceforge.net/projects/geoserver/files/GeoServer/2.9.1/geoserver-2.9.1-bin.zip/download), [war](https://sourceforge.net/projects/geoserver/files/GeoServer/2.9.1/geoserver-2.9.1-war.zip/download), [dmg](https://sourceforge.net/projects/geoserver/files/GeoServer/2.9.1/geoserver-2.9.1.dmg/download) and [exe](https://sourceforge.net/projects/geoserver/files/GeoServer/2.9.1/geoserver-2.9.1.exe/download)) along with documentation and extensions.

--- a/_posts/2016-08-12-geoserver-2-8-5-released.md
+++ b/_posts/2016-08-12-geoserver-2-8-5-released.md
@@ -9,6 +9,7 @@ title: GeoServer 2.8.5 Released
 wordpress_id: 2695
 categories:
 - Announcements
+- Vulnerability
 ---
 
 

--- a/_posts/2016-11-25-geoserver-2-9-3-released.md
+++ b/_posts/2016-11-25-geoserver-2-9-3-released.md
@@ -9,6 +9,7 @@ title: GeoServer 2.9.3 Released
 wordpress_id: 2775
 categories:
 - Announcements
+- Vulnerability
 tags:
 - maintenance
 - release

--- a/_posts/2016-12-21-geoserver-2-10-1-released.md
+++ b/_posts/2016-12-21-geoserver-2-10-1-released.md
@@ -9,6 +9,7 @@ title: GeoServer 2.10.1 Released
 wordpress_id: 2777
 categories:
 - Announcements
+- Vulnerability
 tags:
 - Release
 release: release_210

--- a/_posts/2017-04-24-geoserver-2-10-3-released.md
+++ b/_posts/2017-04-24-geoserver-2-10-3-released.md
@@ -9,6 +9,7 @@ title: GeoServer 2.10.3 Released
 wordpress_id: 2859
 categories:
 - Announcements
+- Vulnerability
 tags:
 - Release
 release: release_2102

--- a/_posts/2017-05-19-geoserver-2-11-1-released.md
+++ b/_posts/2017-05-19-geoserver-2-11-1-released.md
@@ -9,6 +9,7 @@ title: GeoServer 2.11.1 Released
 wordpress_id: 2867
 categories:
 - Announcements
+- Vulnerability
 tags:
 - Release
 release: release_211

--- a/_posts/2017-06-21-geoserver-2-10-4-released.md
+++ b/_posts/2017-06-21-geoserver-2-10-4-released.md
@@ -9,6 +9,7 @@ title: GeoServer 2.10.4 Released
 wordpress_id: 2881
 categories:
 - Announcements
+- Vulnerability
 tags:
 - Release
 release: release_2102

--- a/_posts/2018-04-25-geoserver-2-12-3-released.md
+++ b/_posts/2018-04-25-geoserver-2-12-3-released.md
@@ -9,6 +9,7 @@ title: GeoServer 2.12.3 Released
 wordpress_id: 2947
 categories:
 - Announcements
+- Vulnerability
 tags:
 - Release
 release: release_212

--- a/_posts/2018-06-20-geoserver-2-12-4-release.md
+++ b/_posts/2018-06-20-geoserver-2-12-4-release.md
@@ -9,6 +9,7 @@ title: GeoServer 2.12.4 Release
 wordpress_id: 2951
 categories:
 - Announcements
+- Vulnerability
 tags:
 - Release
 release: release_212

--- a/_posts/2018-07-25-geoserver-2-13-2-released.md
+++ b/_posts/2018-07-25-geoserver-2-13-2-released.md
@@ -9,6 +9,7 @@ title: GeoServer 2.13.2 released
 wordpress_id: 2953
 categories:
 - Announcements
+- Vulnerability
 tags:
 - Release
 release: release_213

--- a/_posts/2018-08-24-geoserver-2-12-5-released.md
+++ b/_posts/2018-08-24-geoserver-2-12-5-released.md
@@ -9,6 +9,7 @@ title: GeoServer 2.12.5 released
 wordpress_id: 2963
 categories:
 - Announcements
+- Vulnerability
 tags:
 - Release
 release: release_212

--- a/_posts/2018-08-28-geoserver-2-14-rc-released.md
+++ b/_posts/2018-08-28-geoserver-2-14-rc-released.md
@@ -9,6 +9,7 @@ title: GeoServer 2.14-RC released
 wordpress_id: 2955
 categories:
 - Announcements
+- Vulnerability
 tags:
 - Release Candidate
 release: release_214

--- a/_posts/2018-09-24-geoserver-2-14-0-released.md
+++ b/_posts/2018-09-24-geoserver-2-14-0-released.md
@@ -9,6 +9,7 @@ title: GeoServer 2.14.0 Released
 wordpress_id: 2969
 categories:
 - Announcements
+- Vulnerability
 tags:
 - Release
 release: release_214

--- a/_posts/2019-11-28-geoserver-2-16-1-released.md
+++ b/_posts/2019-11-28-geoserver-2-16-1-released.md
@@ -9,6 +9,7 @@ title: GeoServer 2.16.1 released
 wordpress_id: 3074
 categories:
 - Announcements
+- Vulnerability
 tags:
 - Release
 release: release_216

--- a/_posts/2021-12-22-geoserver-2-19-4-released.md
+++ b/_posts/2021-12-22-geoserver-2-19-4-released.md
@@ -7,6 +7,7 @@ version: 2.19.4
 jira_version: 16832
 categories: 
  - Announcements
+ - Vulnerability
 tags:
  - Release
 ---

--- a/_posts/2022-01-24-geoserver-2-20-2-released.md
+++ b/_posts/2022-01-24-geoserver-2-20-2-released.md
@@ -7,6 +7,7 @@ categories:
 - Announcements
 tags:
 - Release
+- Vulnerability
 release: release_220
 version: 2.20.2
 jira_version: 16835


### PR DESCRIPTION
This is an experiment, not we do not have a landing page for vulnerability category; so this only shows up in the sidebar when viewing a blog post.


Used grep to locate announcements with "security considerations" and marked with the vulnerability category so we would have a list.