### PR TITLE
Look up latest stable, release and maintain pages and jira information

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,24 +89,18 @@ process of updating site contents for a stable release.
      
      The value for ``jira_version`` can be found by navigating to that version on [Jira](https://osgeo-org.atlassian.net/projects/GEOS?selectedItem=com.atlassian.jira.jira-projects-plugin:release-page) and examining the URL. For example, for example, ``2.7.2`` links to ``https://osgeo-org.atlassian.net/projects/GEOS/versions/10601``, giving a ``jira_version`` of ``10601``. For a maintenance or development release, instead modify ``release/maintain/index.html`` or ``release/dev/index.html`` respectively.
 
-2. Update ``_config.yml`` and update the ``stable_version`` property to the current version.
-   
-   * This change will be reflected in ``index.html`` and ``download/index.html``, and the matching release announcement post will be used to generate the ``release/stable`` page.
+2. Update ``_config.yml`` (this change will be reflected in ``index.html`` and ``download/index.html`):
      
-     Update ``stable_jira`` to be the same as the next release, this is used for the Nightly build page.
+   * Update ``stable_jira`` to be the same as the next release, this is used for the Nightly build page.
      
-     ```
-     stable_version:   2.19.1
+     å```
      stable_jira:      16821
-     stable_branch:    2.19.x
      ```
    
-   * For a maintenance instead change ``maintain_version``, and ``maintain_jira``.
+   * For a maintenance instead change ``maintain_jira``.
    
      ```
-     maintain_version: 2.18.3
      maintain_jira:    16819
-     maintain_branch:  2.18.x
      ```
 
 ### Dev Releases
@@ -117,24 +111,17 @@ When publishing a milestone, beta or release candidate:
 
    This is the value used for ``release`` when making your announcement blog posts.
   
-2. Update ``_config.yml`` update ``dev_version``, the matching release announcement post will be used to generate `release/dev/index.html` page.
+2. Update ``_config.yml`` update ``dev_series`` and ``dev_branch``, the matching release announcement post will be used to generate `release/dev/index.html` page.
 
    ```
-   dev_version:    2.19-RC
-   ```
-   
-4. When no ``dev_version`` is specified `dev_branch`, `dev_jira` and `dev_series` will be used to generate a placeholder `release/dev/index.html` page.
-  
-   ```
-   dev_branch:       main
-   dev_jira:         16815
-   dev_series:       2.20.x
+   dev_series:       2.21.x
+   dev_branch:       2.21.x
    ```
 
 3. Update the `main_series`, and `main_jira` to reflect the new version number for `main` branch, this will be used to generate a placeholder for `release/main/index.html` page.
    ```
-   main_jira:         16829
-   main_series:       2.21.x
+   main_series:       2.22.x
+   main_jira:        16829
    ```
 
 ### Final Release
@@ -143,19 +130,21 @@ When creating the final release:
 
 1. Update the ``_config.yml`` properties:
 
-   * Update the `maintain_version`, `maintain_jira` and `maintain_branch` using the values from `stable`.
+   * Update the `maintain_branch` using the values from `stable`.
+   * Update the `stable_branch`.
    
-   * Update the `stable_version`, `stable_jira` and `stable_branch`.
-   
-2. The ``dev_version``property in ``_config.yml`` should be blank (as the development period is now over).
-   
-   Update the `dev_branch` information. For example, if creating the branch `2.21.x`:
+2. Update the `main_series` and `main_series` information. For example, when starting the series `2.22.x`:
    
    ```
-   dev_version:
-   dev_branch:       main
-   dev_jira:         17823
-   dev_series:       2.21.x
+   main_series:      2.22.x
+   main_jira:        16829_
+   ```
+
+3. The ``dev_series`` and ``dev_branch`` property in ``_config.yml`` to the new series, these will no longer match any posts as the development period is over:
+
+   ```
+   dev_series:       main
+   dev_branch:       2.22.x
    ```
 
 ## Technical Details

--- a/_config.yml
+++ b/_config.yml
@@ -9,30 +9,26 @@ sf_url:      https://sourceforge.net/projects/geoserver
 nightly_url: https://build.geoserver.org/geoserver
 docs_url:    https://docs.geoserver.org
 
-# stable latest release
-stable_version:   2.20.3
-
-# stable nightly build
+# stable      (determine nightly build, stable_version)
 stable_branch:    2.20.x
 stable_jira:      16842
 
-# maintenance latest release
-maintain_version: 2.19.5
-
-# maintenance nightly build
+# maintenance (determine nightly build, maintain_version)
 maintain_branch:  2.19.x
+
+# the next jira release for the maintenance branch
 maintain_jira:    16843
 
 # release candidate if available 
-dev_version:      
+# dev         (determine dev_version)
 dev_branch:       main
-dev_jira:         
 dev_series:       2.21.x
 
-# latest
-main_jira:        16829
+# latest nightly build
 main_series:      2.21.x
 
+# the next jira release for the maintenance branch
+main_jira:        16829
 
 timezone:    UTC
 name:        GeoServer

--- a/_plugins/release.rb
+++ b/_plugins/release.rb
@@ -37,7 +37,42 @@ module ReleasePlugin
       end
       site.data['releases'] = releases
       
+      # Can we determine latest stable and maintenance page?
+      p 'Review posts to identify latest releases'
+      for item in releases
+         if item[0] == site.config['dev_series'].chomp('.x')
+           dev_latest = item[1].last
+           p '  Identify dev_version=' + dev_latest
+           site.config['dev_version'] = dev_latest
+         elsif item[0] == site.config['stable_branch'].chomp('.x')
+           stable_latest = item[1].last
+           p '  Identify stable_version=' + stable_latest
+           site.config['stable_version'] = stable_latest
+         elsif item[0] == site.config['maintain_branch'].chomp('.x')
+           maintain_latest = item[1].last
+           p '  Identify maintain_version=' + maintain_latest
+           site.config['maintain_version'] = maintain_latest
+         end
+      end
       
+      # look up latest deatils
+      p 'Review posts to identify latest release jira details'
+      
+      site.posts.docs.each do |post|
+        if post.data.has_key?('release')
+          if post.data['version'] == site.config['stable_version']
+             site.config['stable_jira'] = post.data['jira_version']
+             p '  Identify ' + post.data['title'] +' stable_jira=' + site.config['stable_jira'].to_s
+          elsif post.data['version'] == site.config['maintain_version']
+             site.config['maintain_jira'] = post.data['jira_version']
+             p '  Identify ' + post.data['title'] +' maintain_jira=' + site.config['maintain_jira'].to_s
+          elsif post.data['version'] == site.config['dev_version']
+             site.config['dev_jira'] = post.data['jira_version']
+             p '  Identify ' + post.data['title'] +' dev_jira=' + site.config['dev_jira'].to_s
+          end
+        end
+      end
+           
       p 'Generating release/main nightly page'
       site.pages << NightlyPage.new(
         site, 


### PR DESCRIPTION
Since we have all the information from posts we should be able to look up latest_version, maintain_version, dev_version (and associated jira information).

This reduce the amount of bother editing config.yaml each release.