### PR TITLE
SEO improvements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 gem 'jekyll-feed'
 gem 'jekyll-paginate'
+gem 'jekyll-sitemap'
 
 gem "webrick", "~> 1.7"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The site is built with [Jekyll](https://github.com/jekyll/jekyll):
 
 #. Before you start:
     
-    gem install bundler jekyll jekyll-feed jekyll-paginate
+    gem install bundler jekyll jekyll-feed jekyll-paginate jekyll-sitemap
 
 #. Jekyll can be run in "watch" mode for development:
 
@@ -171,6 +171,7 @@ The Jekyll build process [goes through several steps](https://jekyllrb.com/tutor
 3. Additional plugins are run:
    
    * jekyll-feed: generates an Atom feed of all the posts
+   * jekyll-sitemap: generates a sitemap of all the pages
    * jekyll-paginate: uses `_blog/index.html` as a template to generate `page2.html`, `page3.html`, ... `page80.html`
 
 4. At this point all the ``site.pages`` are created each containing:

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,7 @@
 plugins:
   - jekyll-feed
   - jekyll-paginate
+  - jekyll-sitemap
 
 jira_url:    https://osgeo-org.atlassian.net/projects/GEOS
 wiki_url:    https://github.com/geoserver/geoserver/wiki
@@ -40,3 +41,15 @@ author:      GeoServer community
 
 paginate: 5
 paginate_path: "/blog/page:num/"
+
+defaults:
+  -
+    scope:
+      path:       "img/**"
+    values:
+      sitemap:    false
+  -
+    scope:
+      path:       "google0de0c8ffb164bba6.html"
+    values:
+      sitemap:    false

--- a/_config.yml
+++ b/_config.yml
@@ -8,6 +8,7 @@ git_url:     https://github.com/geoserver/geoserver
 sf_url:      https://sourceforge.net/projects/geoserver
 nightly_url: https://build.geoserver.org/geoserver
 docs_url:    https://docs.geoserver.org
+url:         https://geoserver.org
 
 # stable      (determine nightly build, stable_version)
 stable_branch:    2.21.x

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,1 @@
+Sitemap: https://geoserver.org/sitemap.xml


### PR DESCRIPTION
## Fix the Jekyll generated feed urls to have the fully qualified domain

Without the fully qualified urls the feed contents, when rendered in a client like Slack or when feeding into Google as an index file, become useless as you can not go to the original content.

As documented here: https://github.com/jekyll/jekyll-feed#usage 

The [current](https://github.com/geoserver/geoserver.github.io/blob/61e1cc21699b45f5776a4879224abaaf66727fd4/feed.xml)

```xml
<?xml version="1.0" encoding="utf-8"?>
<feed xmlns="http://www.w3.org/2005/Atom">
  <generator uri="https://jekyllrb.com/" version="4.2.1">Jekyll</generator>
  <link href="/feed.xml" rel="self" type="application/atom+xml" />
  <link href="/" rel="alternate" type="text/html" />
  <updated>2022-08-15T13:27:57+00:00</updated>
  <id>/feed.xml</id>
  <title type="html">GeoServer</title>
  <subtitle>GeoServer latest posts</subtitle>
  <author>
    <name>GeoServer community</name>
  </author>
  <entry>
    <title type="html">GeoServer 2.21.1 Release</title>
    <link href="/announcements/2022/08/01/geoserver-2-21-1-released.html" rel="alternate" type="text/html" title="GeoServer 2.21.1 Release" />
    <published>2022-08-01T00:00:00+00:00</published>
    <updated>2022-08-01T00:00:00+00:00</updated>
    <id>/announcements/2022/08/01/geoserver-2-21-1-released</id>
    <content type="html" xml:base="/announcements/2022/08/01/geoserver-2-21-1-released.html">

```

becomes

```xml
<?xml version="1.0" encoding="utf-8"?>
<feed xmlns="http://www.w3.org/2005/Atom">
  <generator uri="https://jekyllrb.com/" version="4.2.1">Jekyll</generator>
  <link href="https://geoserver.org/feed.xml" rel="self" type="application/atom+xml" />
  <link href="https://geoserver.org/" rel="alternate" type="text/html" />
  <updated>2022-08-15T13:27:57+00:00</updated>
  <id>https://geoserver.org/feed.xml</id>
  <title type="html">GeoServer</title>
  <subtitle>GeoServer latest posts</subtitle>
  <author>
    <name>GeoServer community</name>
  </author>
  <entry>
    <title type="html">GeoServer 2.21.1 Release</title>
    <link href="https://geoserver.org/announcements/2022/08/01/geoserver-2-21-1-released.html" rel="alternate" type="text/html" title="GeoServer 2.21.1 Release" />
    <published>2022-08-01T00:00:00+00:00</published>
    <updated>2022-08-01T00:00:00+00:00</updated>
    <id>https://geoserver.org/announcements/2022/08/01/geoserver-2-21-1-released</id>
    <content type="html" xml:base="https://geoserver.org/announcements/2022/08/01/geoserver-2-21-1-released.html">
```

when merged.

## Add sitemap

Use the `jekyll-sitemap` to generate a sitemap that can be fed to search engines for better indexing.