### PR TITLE
announcement cleanup

### DIFF
--- a/_posts/2023-03-14-geoserver-2-23-RC1-released.md
+++ b/_posts/2023-03-14-geoserver-2-23-RC1-released.md
@@ -186,10 +186,12 @@ For the complete list see [2.23-RC1](https://github.com/geoserver/geoserver/rele
 
 ## About GeoServer 2.23 Series
 
-Release notes:
-( [2.23-RC1](https://github.com/geoserver/geoserver/releases/tag/2.23-RC1)
-)
+Additional information on GeoServer 2.23 series:
 
 * [Drop Java 8](https://github.com/geoserver/geoserver/wiki/GSIP-215)
 * [GUI CSS Cleanup](https://github.com/geoserver/geoserver/wiki/GSIP-213)
 * [Add the possibility to use fixed values in Capabilities for Dimension metadata](https://github.com/geoserver/geoserver/wiki/GSIP-208)
+
+Release notes:
+( [2.23-RC1](https://github.com/geoserver/geoserver/releases/tag/2.23-RC1)
+)

--- a/_posts/2023-05-05-geoserver-2-22-3-released.md
+++ b/_posts/2023-05-05-geoserver-2-22-3-released.md
@@ -17,14 +17,19 @@ GeoServer [2.22.3](/release/2.22.3/) release is now available with downloads ([b
 This is a maintenance release of the GeoServer 2.22.x series, made in conjunction with GeoTools 28.3 
 and GeoWebCache 1.22.2.
 
-
 Thanks to Daniele Romagnoli (GeoSolutions) for making this release.
 
+### Feature Type Description
+
+Building on top of the ability to customize FeatureTypes GeoServer can now define a description for each attribute. This information is used in WFS DescribeFeatureType to provide a human readable name or description for the attributes being published.
+
+![Attribute Descriptions](/img/posts/2.23/attribute_description.png) <br/>
+
+Thanks to Joseph Miller (GeoSolutions) for this improvement.
+
+* [GEOS-10868](https://osgeo-org.atlassian.net/browse/GEOS-10868) Add support for editable description in GeoServer customize feature type table
+
 ### Release notes
-
-Sub-task:
-
-* [GEOS-10908](https://osgeo-org.atlassian.net/browse/GEOS-10908) Update spring version from 5.2.22 to 5.2.23
 
 Bug:
 
@@ -78,21 +83,19 @@ Improvement:
 
 * [GEOS-10858](https://osgeo-org.atlassian.net/browse/GEOS-10858) jdbc-config turns off isolated workspace support
 
-* [GEOS-10867](https://osgeo-org.atlassian.net/browse/GEOS-10867) Bump commons-fileupload from 1.4 to 1.5
-
 * [GEOS-10870](https://osgeo-org.atlassian.net/browse/GEOS-10870) Allow importer AttributesToPointGeometryTransform to preserve original geometries, and to configure the name of the target geometry
-
-* [GEOS-10873](https://osgeo-org.atlassian.net/browse/GEOS-10873) Upgrade XStream to 1.4.20
 
 * [GEOS-10898](https://osgeo-org.atlassian.net/browse/GEOS-10898) Preserve key order in STAC responses coming from JSONB columns
 
 * [GEOS-10923](https://osgeo-org.atlassian.net/browse/GEOS-10923) Use default writing params on GeoTIFFPPIO
 
-New Feature:
-
-* [GEOS-10868](https://osgeo-org.atlassian.net/browse/GEOS-10868) Add support for editable description in GeoServer customize feature type table
-
 Task:
+
+* [GEOS-10908](https://osgeo-org.atlassian.net/browse/GEOS-10908) Update spring version from 5.2.22 to 5.2.23
+
+* [GEOS-10867](https://osgeo-org.atlassian.net/browse/GEOS-10867) Bump commons-fileupload from 1.4 to 1.5
+
+* [GEOS-10873](https://osgeo-org.atlassian.net/browse/GEOS-10873) Upgrade XStream to 1.4.20
 
 * [GEOS-10863](https://osgeo-org.atlassian.net/browse/GEOS-10863) Update Oracle JDBC driver to 19.18.0.0
 

--- a/_posts/2023-05-08-geoserver-2-21-5-released.md
+++ b/_posts/2023-05-08-geoserver-2-21-5-released.md
@@ -21,10 +21,6 @@ Thanks to Daniele Romagnoli (GeoSolutions) for making this release.
 
 ### Release notes
 
-Sub-task
-
-* [GEOS-10908](https://osgeo-org.atlassian.net/browse/GEOS-10908) Update spring version from 5.2.22 to 5.2.23
-
 Bug
 
 * [GEOS-3978](https://osgeo-org.atlassian.net/browse/GEOS-3978) Layer configuration allows admin to enter a zero area bounding box
@@ -69,20 +65,32 @@ Bug
 
 Improvement
 
-* [GEOS-10867](https://osgeo-org.atlassian.net/browse/GEOS-10867) Bump commons-fileupload from 1.4 to 1.5
-
 * [GEOS-10870](https://osgeo-org.atlassian.net/browse/GEOS-10870) Allow importer AttributesToPointGeometryTransform to preserve original geometries, and to configure the name of the target geometry
-
-* [GEOS-10873](https://osgeo-org.atlassian.net/browse/GEOS-10873) Upgrade XStream to 1.4.20
 
 * [GEOS-10940](https://osgeo-org.atlassian.net/browse/GEOS-10940) Update MapML viewer to release 0.11.0
 
 Task
 
+* [GEOS-10867](https://osgeo-org.atlassian.net/browse/GEOS-10867) Bump commons-fileupload from 1.4 to 1.5
+
+* [GEOS-10873](https://osgeo-org.atlassian.net/browse/GEOS-10873) Upgrade XStream to 1.4.20
+
+* [GEOS-10908](https://osgeo-org.atlassian.net/browse/GEOS-10908) Update spring version from 5.2.22 to 5.2.23
+
 * [GEOS-10863](https://osgeo-org.atlassian.net/browse/GEOS-10863) Update Oracle JDBC driver to 19.18.0.0
 
 * [GEOS-10904](https://osgeo-org.atlassian.net/browse/GEOS-10904) Bump jettison from 1.5.3 to 1.5.4
 
+For complete information see [2.22.5 release 
+notes](https://github.com/geoserver/geoserver/releases/tag/2.21.5).
+
+## About GeoServer 2.21
+
+Additional information on GeoServer 2.21 series:
+
+- [Feature Type Customization](https://github.com/geoserver/geoserver/wiki/GSIP-207)
+- [Add Styles support to LayerGroup](https://github.com/geoserver/geoserver/wiki/GSIP-205)
+- [Log4j1 update or replace activity]({% post_url 2022-01-20-log4j-upgrade %})
 
 Release notes:
 ( [2.21.5](https://github.com/geoserver/geoserver/releases/tag/2.21.5)

--- a/_posts/2023-05-23-geoserver-2-23-1-released.md
+++ b/_posts/2023-05-23-geoserver-2-23-1-released.md
@@ -18,63 +18,69 @@ This is a stable release of GeoServer suitable for production systems, made in c
 
 We are grateful to Ian Turton (Astun Technology Ltd) for making this release. 
 
-# Release notes - GeoServer - 2.23.1
+### Release notes
 
-### Bug
+Improvement:
 
-[GEOS-8162](https://osgeo-org.atlassian.net/browse/GEOS-8162) CSV Data store does not support relative store paths
+* [GEOS-10858](https://osgeo-org.atlassian.net/browse/GEOS-10858) jdbc-config turns off isolated workspace support
 
-[GEOS-10837](https://osgeo-org.atlassian.net/browse/GEOS-10837) geopackage output fails when `java.io.tmpdir` 
+* [GEOS-10898](https://osgeo-org.atlassian.net/browse/GEOS-10898) Preserve key order in STAC responses coming from JSONB columns
+
+* [GEOS-10923](https://osgeo-org.atlassian.net/browse/GEOS-10923) Use default writing params on `GeoTIFFPPIO`
+
+* [GEOS-10940](https://osgeo-org.atlassian.net/browse/GEOS-10940) Update MapML viewer to release 0.11.0
+
+Bug:
+
+* [GEOS-8162](https://osgeo-org.atlassian.net/browse/GEOS-8162) CSV Data store does not support relative store paths
+
+* [GEOS-10837](https://osgeo-org.atlassian.net/browse/GEOS-10837) geopackage output fails when `java.io.tmpdir` 
 on network share
 
-[GEOS-10912](https://osgeo-org.atlassian.net/browse/GEOS-10912) jms-cluster fails to clone grid coverage layer on other nodes
+* [GEOS-10912](https://osgeo-org.atlassian.net/browse/GEOS-10912) jms-cluster fails to clone grid coverage layer on other nodes
 
-[GEOS-10920](https://osgeo-org.atlassian.net/browse/GEOS-10920) Excel output format packaging misses dependencies, cannot produce .xls
+* [GEOS-10920](https://osgeo-org.atlassian.net/browse/GEOS-10920) Excel output format packaging misses dependencies, cannot produce .xls
 
-[GEOS-10921](https://osgeo-org.atlassian.net/browse/GEOS-10921) Double escaping of HTML with enabled features-templating
+* [GEOS-10921](https://osgeo-org.atlassian.net/browse/GEOS-10921) Double escaping of HTML with enabled features-templating
 
-[GEOS-10922](https://osgeo-org.atlassian.net/browse/GEOS-10922) Features templating exception on text/plain format
+* [GEOS-10922](https://osgeo-org.atlassian.net/browse/GEOS-10922) Features templating exception on text/plain format
 
-[GEOS-10932](https://osgeo-org.atlassian.net/browse/GEOS-10932) csw-iso: should only add `'xsi:nil = false'` 
+* [GEOS-10932](https://osgeo-org.atlassian.net/browse/GEOS-10932) csw-iso: should only add `'xsi:nil = false'` 
 attribute
 
-[GEOS-10934](https://osgeo-org.atlassian.net/browse/GEOS-10934) CSW does not show title/abstract on welcome page
+* [GEOS-10934](https://osgeo-org.atlassian.net/browse/GEOS-10934) CSW does not show title/abstract on welcome page
 
-[GEOS-10946](https://osgeo-org.atlassian.net/browse/GEOS-10946) WMS `GetLegendGraphic` throws 
+* [GEOS-10946](https://osgeo-org.atlassian.net/browse/GEOS-10946) WMS `GetLegendGraphic` throws 
 `FootprintsTransformation` cannot be cast to `ProcessFunctionException`
 
-[GEOS-10950](https://osgeo-org.atlassian.net/browse/GEOS-10950) Performance regression in 
+* [GEOS-10950](https://osgeo-org.atlassian.net/browse/GEOS-10950) Performance regression in 
 `DescribeFeatureType` across all feature types
 
-[GEOS-10955](https://osgeo-org.atlassian.net/browse/GEOS-10955) STAC templates are initialised in the wrong location
+* [GEOS-10955](https://osgeo-org.atlassian.net/browse/GEOS-10955) STAC templates are initialised in the wrong location
 
-[GEOS-10957](https://osgeo-org.atlassian.net/browse/GEOS-10957) Support `ResourceAccessManager` 
+* [GEOS-10957](https://osgeo-org.atlassian.net/browse/GEOS-10957) Support `ResourceAccessManager` 
 implementations returning custom subclasess of `AccessLimits`
 
-[GEOS-10969](https://osgeo-org.atlassian.net/browse/GEOS-10969) Empty `CQL_FILTER` parameter should be ignored
+* [GEOS-10969](https://osgeo-org.atlassian.net/browse/GEOS-10969) Empty `CQL_FILTER` parameter should be ignored
 
-[GEOS-10975](https://osgeo-org.atlassian.net/browse/GEOS-10975) JMS clustering reports error about 
+* [GEOS-10975](https://osgeo-org.atlassian.net/browse/GEOS-10975) JMS clustering reports error about 
 `ReferencedEnvelope` type not being whitelisted in XStream
 
-[GEOS-10985](https://osgeo-org.atlassian.net/browse/GEOS-10985) B/R of GeoServer catalog is broken with GeoServer 2.23.0
+* [GEOS-10985](https://osgeo-org.atlassian.net/browse/GEOS-10985) B/R of GeoServer catalog is broken with GeoServer 2.23.0
 
-### Improvement
+Task:
 
-[GEOS-10858](https://osgeo-org.atlassian.net/browse/GEOS-10858) jdbc-config turns off isolated workspace support
-
-[GEOS-10898](https://osgeo-org.atlassian.net/browse/GEOS-10898) Preserve key order in STAC responses coming from JSONB columns
-
-[GEOS-10923](https://osgeo-org.atlassian.net/browse/GEOS-10923) Use default writing params on `GeoTIFFPPIO`
-
-[GEOS-10940](https://osgeo-org.atlassian.net/browse/GEOS-10940) Update MapML viewer to release 0.11.0
-
-### Task
-
-[GEOS-10859](https://osgeo-org.atlassian.net/browse/GEOS-10859) OGC API: swagger-api 4.15.5 upgrade
+* [GEOS-10859](https://osgeo-org.atlassian.net/browse/GEOS-10859) OGC API: swagger-api 4.15.5 upgrade
 
 For the complete list see [2.23.1](https://github.com/geoserver/geoserver/releases/tag/2.23.1) release notes.
 
 ## About GeoServer 2.23 Series
+
+Additional information on GeoServer 2.23 series:
+
+* [Drop Java 8](https://github.com/geoserver/geoserver/wiki/GSIP-215)
+* [GUI CSS Cleanup](https://github.com/geoserver/geoserver/wiki/GSIP-213)
+* [Add the possibility to use fixed values in Capabilities for Dimension metadata](https://github.com/geoserver/geoserver/wiki/GSIP-208)
 
 Release notes:
 ( 
@@ -82,7 +88,3 @@ Release notes:
 | [2.23.0](https://github.com/geoserver/geoserver/releases/tag/2.23.0)
 | [2.23-RC1](https://github.com/geoserver/geoserver/releases/tag/2.23-RC1)
 )
-
-* [Drop Java 8](https://github.com/geoserver/geoserver/wiki/GSIP-215)
-* [GUI CSS Cleanup](https://github.com/geoserver/geoserver/wiki/GSIP-213)
-* [Add the possibility to use fixed values in Capabilities for Dimension metadata](https://github.com/geoserver/geoserver/wiki/GSIP-208)


### PR DESCRIPTION
Do we really need to include copy and paste of release notes?

@ianturton / @dromagnoli I believe we are working too hard and not adding value when copying and pasting release notes.

We hand edit for the major releases taking care to introduce new features, security vulnerabilities, and isolate community module updates into their own heading, translate bug reports (this does not work) into fixes (this is fixed).

When we drop down to copying and pasting release notes it is duplicating information, and changes the nature of the communication: it is no longer an announcement.

Recommendation:

- do not copy and paste release notes, just link to the release notes in github
- document security vulnerabilities (if details cannot be disclosed a generic blurb is fine)
- document new features; it is easy to back port the text, or if you are documenting a new feature coming from ``main`` we should be writing a new feature heading anyways ...
- trust the linked release notes to cover any community module changes
- document config changes (even if just fixing a regression) with links to [upgrade](https://docs.geoserver.org/stable/en/user/installation/upgrade.html) on any things to fix by hand
- preserve the "about the 23.x series" heading highlighting new features (often these link to documentation)
- aside: version upgrades are *tasks* not an *improvement* (just so they all group together)

The attached PR does not implement all of the above changes; only makes the last couple of releases consistent.