### PR TITLE
Release announcement generation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ process of updating site contents for a stable release.
    * The header information should be correct, picking up your user name from git global config
    * Check the included release notes
    * Include a security vulnerability section with ``-security``
-   * Use ``-maintenance`` to indicate a maintenance release.
+   * Announcement text based on version, use ``-stable`` or ``-maintenance`` to override
    
    if everything looks good genearte post using (the date for the generated post is supplied by Jira):
    
@@ -119,12 +119,14 @@ process of updating site contents for a stable release.
      
      The value for ``jira_version`` can be found by navigating to that version on [Jira](https://osgeo-org.atlassian.net/projects/GEOS?selectedItem=com.atlassian.jira.jira-projects-plugin:release-page) and examining the URL. For example, for example, ``2.7.2`` links to ``https://osgeo-org.atlassian.net/projects/GEOS/versions/10601``, giving a ``jira_version`` of ``10601``. For a maintenance or development release, instead modify ``release/maintain/index.html`` or ``release/dev/index.html`` respectively.
 
+2. The generated post is 90% complete.
+
    Check one of the previous blog posts so we end up with a consistent format.
    
-   Links to documentation or proposals are added to the "about section" at the end of the anouncement.
+   * GeoTools and GeoWebCache version numbers will need to be supplied
+   * Copy and paste "about section" at end of post with links to documentation / proposals / presentations
 
-
-2. Update ``_config.yml`` (this change will be reflected in ``index.html`` and ``download/index.html``):
+3. Update ``_config.yml`` (this change will be reflected in ``index.html`` and ``download/index.html``):
      
    * Update ``stable_jira`` to be the same as the next release, this is used for the Nightly build page.
      
@@ -184,7 +186,18 @@ When creating the final release:
 
 ## Technical Details
 
-### Jekyll Build 
+
+### Anouncement generation
+
+The python anouncement.py script makes use of the Jira REST API to determine information about the release being made.
+
+It does check that the release is made, in order to ensure to ensure that a release date is provided.
+
+The specific text genrated is based on checking the version number (for ``RC`` release candidate, ``M`` milestone, ``<4`` stable, or ``maintenance``).
+
+The security consideration sections is optional, both including the post content and updating the header tags so the post is correctly indexed.
+
+### Jekyll Build
 
 The Jekyll build process [goes through several steps](https://jekyllrb.com/tutorials/orderofinterpretation/):
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,26 @@ process of updating site contents for a stable release.
 1. Write a blog post announcing the new release.
    
    ```
+   cd bin
+   python3 anouncement.py username password 2.23.2
+   ```
+   
+   A post is generated to standard out for your review.
+   
+   * The header information should be correct, picking up your user name from git global config
+   * Check the included release notes
+   * Include a security vulnerability section with ``-security``
+   * Use ``-maintenance`` to indicate a maintenance release.
+   
+   if everything looks good genearte post using (the date for the generated post is supplied by Jira):
+   
+   ```
+   python3 anouncement.py username password 2.23.2 -post
+   ```
+   
+   Release posts have the following format
+   
+   ```
    ---
    author: Andrea Aime
    layout: post
@@ -84,18 +104,25 @@ process of updating site contents for a stable release.
    jira_version: 16816
    ---
    ```
-   
-   Copy one of the previous blog posts so we end up with a consistent format.
-   
+      
    The following information is used to generate a ``release/<version>/index.html`` page:
    
    * ``release``: This is the `_layout` used for the generated release page
+   
+   * Tags are used to indicate ``Release``, ``Release Candidate``, ``Milestone``. 
+      
+     The ``Vulnerability`` tag is used to highlight blog posts and release anouncements covering a security topic. 
    
    * ``version``: The GeoServer version being announced
    
    * ``jira_version``: Used to link to the release notes
      
      The value for ``jira_version`` can be found by navigating to that version on [Jira](https://osgeo-org.atlassian.net/projects/GEOS?selectedItem=com.atlassian.jira.jira-projects-plugin:release-page) and examining the URL. For example, for example, ``2.7.2`` links to ``https://osgeo-org.atlassian.net/projects/GEOS/versions/10601``, giving a ``jira_version`` of ``10601``. For a maintenance or development release, instead modify ``release/maintain/index.html`` or ``release/dev/index.html`` respectively.
+
+   Check one of the previous blog posts so we end up with a consistent format.
+   
+   Links to documentation or proposals are added to the "about section" at the end of the anouncement.
+
 
 2. Update ``_config.yml`` (this change will be reflected in ``index.html`` and ``download/index.html``):
      

--- a/README.md
+++ b/README.md
@@ -72,20 +72,21 @@ process of updating site contents for a stable release.
    
    ```
    cd bin
-   python3 anouncement.py username password 2.23.2
+   python3 anouncement.py username password 2.23.2 --geotools  29.2 --geowebcache 1.23.2
    ```
    
    A post is generated to standard out for your review.
    
    * The header information should be correct, picking up your user name from git global config
    * Check the included release notes
-   * Include a security vulnerability section with ``-security``
-   * Announcement text based on version, use ``-stable`` or ``-maintenance`` to override
+   * Edit ``bin/templates/aboutXXX.md`` to list any new features for the about section
+   * Force a security vulnerability section with ``--security`` (although this will be added if any issues with component ``Vulnerability`` are included in the release)
+   * Announcement text based on version, use ``--override stable`` or ``--override maintenance`` if the guess was incorrect
    
    if everything looks good genearte post using (the date for the generated post is supplied by Jira):
    
    ```
-   python3 anouncement.py username password 2.23.2 -post
+   python3 anouncement.py username password 2.23.2 --geotools  29.2 --geowebcache 1.23.2 --post
    ```
    
    Release posts have the following format
@@ -123,8 +124,8 @@ process of updating site contents for a stable release.
 
    Check one of the previous blog posts so we end up with a consistent format.
    
-   * GeoTools and GeoWebCache version numbers will need to be supplied
-   * Copy and paste "about section" at end of post with links to documentation / proposals / presentations
+   * GeoTools and GeoWebCache version numbers will need to be supplied on the command line
+   * Check the "about section" at end of post with links to documentation / proposals / presentations
 
 3. Update ``_config.yml`` (this change will be reflected in ``index.html`` and ``download/index.html``):
      
@@ -186,14 +187,15 @@ When creating the final release:
 
 ## Technical Details
 
-
 ### Anouncement generation
 
 The python anouncement.py script makes use of the Jira REST API to determine information about the release being made.
 
+Posts are generated using Jenga2 templates located in ``bin/templates``. You can fine tune the about section for each series by adding ``aboutXXX.md`` file documenting new features.
+
 It does check that the release is made, in order to ensure to ensure that a release date is provided.
 
-The specific text genrated is based on checking the version number (for ``RC`` release candidate, ``M`` milestone, ``<4`` stable, or ``maintenance``).
+The specific text genrated is based on checking the version number (for ``RC`` release candidate, ``M`` milestone, ``<4`` stable, or ``<7`` maintenance``).
 
 The security consideration sections is optional, both including the post content and updating the header tags so the post is correctly indexed.
 

--- a/_posts/2023-02-20-geoserver-2-20-7-released.md
+++ b/_posts/2023-02-20-geoserver-2-20-7-released.md
@@ -15,7 +15,7 @@ jira_version: 16864
 
 GeoServer [2.20.7](/release/2.20.7/) release is available with downloads ([bin](https://sourceforge.net/projects/geoserver/files/GeoServer/2.20.7/geoserver-2.20.7-bin.zip/download), [war](https://sourceforge.net/projects/geoserver/files/GeoServer/2.20.7/geoserver-2.20.7-war.zip/download), [windows](https://sourceforge.net/projects/geoserver/files/GeoServer/2.20.7/GeoServer-2.20.7-winsetup.exe/download)), along with [docs](https://sourceforge.net/projects/geoserver/files/GeoServer/2.20.7/geoserver-2.20.7-htmldoc.zip/download) and [extensions](https://sourceforge.net/projects/geoserver/files/GeoServer/2.20.7/extensions/).
 
-This series has previously reached end-of-life, with release being issued to address a urdent security vulnerability. Please apply this upgrade as a mitigation measure only. Upgrade to 2.22.x series for community support.
+This series has previously reached end-of-life, with a release being issued to address an urdent security vulnerability. Please apply this upgrade as a mitigation measure only. Upgrade to 2.22.x series for community support.
 
 Thanks to Andrea Aime (GeoSolutions) for making this update available on behalf of the GeoNode project.
 

--- a/bin/anouncement.py
+++ b/bin/anouncement.py
@@ -1,0 +1,254 @@
+#!/usr/bin/python3
+
+# From https://community.atlassian.com/t5/Jira-Software-questions/Is-there-a-way-to-use-the-JIRA-API-to-retrieve-Release-Notes-of/qaq-p/1678046
+#
+# Vincent Richard
+# Feb 17, 2022
+# Hi, I'm not an expert in Python but still, I ended up writing a little script doing the job. It takes three parameters :
+# 1 - A username
+# 2 - A password
+# 3 - A part of the version name (I use it with X.Y.Z knowing that I don't have two version names containing the same version numbers)
+
+import subprocess, os, sys, requests, json
+
+def printUsage():
+    print("python3 anouncement.py [-post] [-security] [-maintenance] username password version")
+
+def releaseName(release):
+    return release['name']
+    
+def getSeriesReleasesFromNamePart(versionNumber):
+    response = requests.get(jiraBaseUrl + 'rest/api/2/project/' + project + '/versions', auth=auth)
+    versions = response.json()
+
+    release = None
+    
+    for version in versions:
+        if (versionNumber in version['name']):
+            release = version
+            break
+    
+    if not release:
+       raise ValueError('Version number ' + versionNumber + ' not found')
+    
+    series = release['name'][0:4]
+    releaseVersions = []
+    for version in versions:
+        if ((version['name'][0:4] == series) and (version['name'] <= release['name'])):
+            releaseVersions.append(version)
+    
+    releaseVersions.sort(key=releaseName,reverse=True)
+    
+    # for version in releaseVersions:
+    #   print( version['name'] + ': '+json.dumps(version))
+       
+    return releaseVersions
+
+def getProjectIssuesFromVersion(projectVersion):
+    jql = 'project = ' + project + ' AND fixVersion = "' + projectVersion['name'] + '" AND resolution IS NOT EMPTY ORDER BY key'
+    params = {'projectId':projectVersion['projectId'], 'maxResults':1000, 'jql':jql}
+    response = requests.get(jiraBaseUrl + '/rest/api/2/search', auth=auth, params=params)
+    return response.json()
+
+def gitUser():
+    output = subprocess.check_output('git config --global user.name', shell=True)
+    return output.decode('utf-8').strip()
+
+def mdHeader(releaseVersion,series,author,secuirty):
+
+
+   name = releaseVersion['name']
+   print(json.dumps(releaseVersion))
+   print('')
+   print('---')
+   print('author: '+author)
+   print('layout: post')
+   print('title: GeoServer '+name+' Released')
+   print('categories:')
+   print(' - Announcements')
+   print('tags:')
+   
+   print(series)
+   
+   match series:
+      case 'release candidate':
+         print('- Release Candidate')
+      case 'milestone':
+         print('- Milestone Release')
+      case _:
+         print('- Release')
+   
+   if secuirty:
+      print('- Vulnerability')
+      
+   print('release: release_'+name[0:1]+''+name[2:4])
+   print('version: '+name)
+   print('jira_version: '+releaseVersion['id'])
+   print('---')
+      
+def mdAnouncement(releaseVersion,series,author):
+    name = releaseVersion['name']
+    
+    print('GeoServer ['+name+'](https://geoserver.org/release/'+name+'/) release is now available')
+    print('with downloads (')
+    print('[bin](https://sourceforge.net/projects/geoserver/files/GeoServer/'+name+'/geoserver-'+name+'-bin.zip/download),')
+    print('[war](https://sourceforge.net/projects/geoserver/files/GeoServer/'+name+'/geoserver-'+name+'-war.zip/download),')
+    print('[windows](https://sourceforge.net/projects/geoserver/files/GeoServer/'+name+'/GeoServer-'+name+'-winsetup.exe/download))')
+    print(', along with ')
+    print('[docs](https://sourceforge.net/projects/geoserver/files/GeoServer/'+name+'/geoserver-'+name+'-htmldoc.zip/download) and')
+    print('[extensions](https://sourceforge.net/projects/geoserver/files/GeoServer/'+name+'/extensions/).')
+    print('')
+    
+    if series == "release candidate":
+       print('This is a release candidate intended for public review and feedback,')
+    elif series == "milestone":
+       print('This is a milestone release providing a preview of upcoming functionality for testing and feedback. This release is')
+    elif series == "maintenance":
+       print('This is a maintenance release of GeoServer provided as an update for production systems. This release is')
+    else:
+       print('This is a stable release of GeoServer recommended for production use,')
+       
+    print('made in conjunction with GeoTools XX.X, and GeoWebCache 1.XX.X.')
+    print('')
+    print('Thanks to '+author+' for making this release.')
+    print('')
+
+def mdSecurityConsiderations():
+    print("## Security Considerations")
+    print('')
+    print('This release addresses a security vulnerabilities and is considered an essential upgrade for production systems.')
+    print('')
+    print('* [CVE-2023-XXXXX Advisory](https://github.com/geoserver/geoserver/security/advisories/GHSA-XXXX-xxxx-xxxx)')
+    print('* [GEOS-XXXX Summary](https://osgeo-org.atlassian.net/browse/GEOS-XXXXX')
+    print('')
+    
+def mdLinkReleaseNotes(versionNumber):
+    return '[' + versionNumber +  '](https://github.com/geoserver/geoserver/releases/tag/'+versionNumber+')'
+
+def mdIssue(issue):
+    print('* [' +  issue['key'] + '](' + jiraBaseUrl + '/browse/' + issue['key'] + ') ' + issue['fields']['summary'])
+
+def collectIssueTypeNames(issues):
+    issueTypeNames = []
+    for issue in issues:
+        typeName = issue['fields']['issuetype']['name']
+        if typeName not in issueTypeNames:
+            issueTypeNames.append(typeName)
+    
+    orderedTypeNames = ['New Feature','Improvement','Bug','Task','Sub-task']
+    for typeName in orderedTypeNames:
+        if typeName not in issueTypeNames:
+           orderedTypeNames.remove(typeName)
+
+    for typeName in issueTypeNames:
+        if typeName not in orderedTypeNames:
+           orderedTypeNames.append(typeName)
+    
+    return orderedTypeNames
+
+def mdReleaseNotes(releaseVersion, projectIssues, releaseVersions):
+        
+    print('## Release notes')
+    
+    issueTypeNames = collectIssueTypeNames(projectIssues['issues'])
+    for issueTypeName in issueTypeNames:
+        print('')
+        print(issueTypeName + ':')
+        print('')
+        for issue in projectIssues['issues']:
+            if issue['fields']['issuetype']['name'] == issueTypeName:
+                mdIssue(issue)
+    print('')
+    print('For the complete list see [' + mdLinkReleaseNotes( releaseVersion['name']) +' release notes.')
+
+    print('')
+    
+def mdSeries(releaseVersion, releaseVersions):
+    print('# About GeoServer ' + releaseVersion['name'][0:4] + ' Series')
+    print('')
+    print('Additional information on GeoServer ' + releaseVersion['name'][0:4] + " series:")
+    print('')
+    print('* ')
+    print('')
+    print('Release notes:')
+    print('( ' + mdLinkReleaseNotes(releaseVersion['name']) )
+    for version in releaseVersions[1:]:
+        print('| ' + mdLinkReleaseNotes(version['name']) )
+    print(')')
+
+project = 'GEOS'
+jiraBaseUrl = 'https://osgeo-org.atlassian.net/'
+post = False
+security = False
+series = 'stable'
+argv = []
+for arg in sys.argv:
+   if arg[0:1] == '-':
+      if arg == "-post":
+          post = True
+      elif arg == "-security":
+          security = True
+      elif arg == "-maintenance":
+          series = 'maintenance'
+      else:
+          printUsage()
+          exit()
+   else:
+      argv.append(arg)
+
+if len(argv) != 4:
+   printUsage()
+   exit()
+
+# auth=(user, password)
+auth=(argv[1], argv[2])
+name = argv[3]
+
+author = gitUser()
+
+if "RC" in name:
+   series = "release candidate"
+elif "M" in name:
+   series = "milestone"
+
+releaseVersions = getSeriesReleasesFromNamePart(name)
+releaseVersion = releaseVersions[0]
+# print(json.dumps(projectVersion, indent=2))
+
+projectIssues = getProjectIssuesFromVersion(releaseVersion)
+# print(json.dumps(projectIssues, indent=2))
+
+if post:
+   if not releaseVersion['released']:
+     print('Release '+name+' not released yet in Jira')
+     print(json.dumps(releaseVersion))
+     exit()
+     
+   elif 'releaseDate' not in releaseVersion or not releaseVersion['releaseDate']:
+     print('Release '+name+' releaseDate not defined in Jira')
+     print(json.dumps(releaseVersion))
+     exit()
+  
+   filename = '../_posts/'+releaseVersion['releaseDate']+'-geoserver-'+name.replace('.','-')+'-released.md'
+      
+   if os.path.exists(filename):
+      print('File already exists: '+filename)
+      exit()
+   
+   print('Generating post to '+filename)
+   print('This is an outline only, some editing will be required!')
+   
+   stdout_fileno = sys.stdout
+   sys.stdout = open(filename, 'w')
+
+mdHeader(releaseVersion,series,author,security)
+mdAnouncement(releaseVersion,series,author)
+if security:
+  mdSecurityConsiderations()
+
+mdReleaseNotes(releaseVersion, projectIssues, releaseVersions)
+mdSeries(releaseVersion,releaseVersions)
+
+if post:
+   sys.stdout.close()
+   sys.stdout = stdout_fileno

--- a/bin/anouncement.py
+++ b/bin/anouncement.py
@@ -1,18 +1,13 @@
 #!/usr/bin/python3
 
-# From https://community.atlassian.com/t5/Jira-Software-questions/Is-there-a-way-to-use-the-JIRA-API-to-retrieve-Release-Notes-of/qaq-p/1678046
+# Requires python 3.10+ for match syntax
 #
-# Vincent Richard
-# Feb 17, 2022
-# Hi, I'm not an expert in Python but still, I ended up writing a little script doing the job. It takes three parameters :
-# 1 - A username
-# 2 - A password
-# 3 - A part of the version name (I use it with X.Y.Z knowing that I don't have two version names containing the same version numbers)
+# Reference: https://community.atlassian.com/t5/Jira-Software-questions/Is-there-a-way-to-use-the-JIRA-API-to-retrieve-Release-Notes-of/qaq-p/1678046
 
 import subprocess, os, sys, requests, json
 
 def printUsage():
-    print("python3 anouncement.py [-post] [-security] [-maintenance] username password version")
+    print("python3 anouncement.py [-post] [-security] [-stable] [-maintenance] username password version")
 
 def releaseName(release):
     return release['name']
@@ -180,16 +175,20 @@ project = 'GEOS'
 jiraBaseUrl = 'https://osgeo-org.atlassian.net/'
 post = False
 security = False
-series = 'stable'
+stable = False
+maintenance = False
 argv = []
+
 for arg in sys.argv:
    if arg[0:1] == '-':
       if arg == "-post":
           post = True
       elif arg == "-security":
           security = True
+      elif arg == "-stable":
+          stable = True
       elif arg == "-maintenance":
-          series = 'maintenance'
+          maintenance = True 
       else:
           printUsage()
           exit()
@@ -204,12 +203,20 @@ if len(argv) != 4:
 auth=(argv[1], argv[2])
 name = argv[3]
 
-author = gitUser()
-
-if "RC" in name:
+if stable:
+   series = 'stable'
+elif maintenance:
+   series = 'maintenance'
+elif "RC" in name:
    series = "release candidate"
 elif "M" in name:
    series = "milestone"
+elif name[5:] < '3':
+   series = 'stable'
+else:
+   series = 'maintenance'
+
+author = gitUser()
 
 releaseVersions = getSeriesReleasesFromNamePart(name)
 releaseVersion = releaseVersions[0]

--- a/bin/templates/about.md
+++ b/bin/templates/about.md
@@ -1,0 +1,18 @@
+# About GeoServer {{ series }} Series
+
+Additional information on GeoServer {{ series }} series:
+
+* [GeoServer {{ series }} User Manual](https://docs.geoserver.org/{{ series }}.x/en/user/)
+{% block features %}
+{% endblock %}
+
+Release notes:
+{% for version in versions %}
+   {%- if loop.index0 == 0 %}
+( 
+   {%- else %}
+|  
+   {%- endif %}
+ [{{version.name}}](https://github.com/geoserver/geoserver/releases/tag/{{version.name}})
+{% endfor %}
+)

--- a/bin/templates/about222.md
+++ b/bin/templates/about222.md
@@ -1,0 +1,10 @@
+{% extends 'about.md' %}
+
+{% block features %}
+* [Update Instructions](https://docs.geoserver.org/latest/en/user/installation/upgrade.html)
+* [Metadata extension](https://docs.geoserver.org/latest/en/user/extensions/metadata/index.html)
+* [CSW ISO Metadata extension](https://docs.geoserver.org/latest/en/user/extensions/csw-iso/index.html)
+* [State of GeoServer](https://docs.google.com/presentation/d/1mnOFSvYb8npVudvUR5MSjSTFHc6ZQ_bStafZrBV7LZ8/edit?usp=sharing) (FOSS4G Presentation)
+* [GeoServer Beginner Workshop](https://docs.google.com/presentation/d/1fbPLN-1Cs95WK-IxDG1PxCEKyHwFbNBGNkkomxmLr0Y/edit?usp=sharing) (FOSS4G Workshop)
+* [Welcome page](https://docs.geoserver.org/latest/en/user/webadmin/welcome.html) (User Guide)
+{% endblock %}

--- a/bin/templates/about223.md
+++ b/bin/templates/about223.md
@@ -1,0 +1,7 @@
+{% extends 'about.md' %}
+
+{% block features %}
+* [Drop Java 8](https://github.com/geoserver/geoserver/wiki/GSIP-215)
+* [GUI CSS Cleanup](https://github.com/geoserver/geoserver/wiki/GSIP-213)
+* [Add the possibility to use fixed values in Capabilities for Dimension metadata](https://github.com/geoserver/geoserver/wiki/GSIP-208)
+{% endblock %}

--- a/bin/templates/announcement.md
+++ b/bin/templates/announcement.md
@@ -1,0 +1,27 @@
+GeoServer [{{release}}](/release/{{release}}/) release is now available
+with downloads (
+[bin](https://sourceforge.net/projects/geoserver/files/GeoServer/{{release}}/geoserver-{{release}}-bin.zip/download),
+[war](https://sourceforge.net/projects/geoserver/files/GeoServer/{{release}}/geoserver-{{release}}-war.zip/download),
+[windows](https://sourceforge.net/projects/geoserver/files/GeoServer/{{release}}/GeoServer-{{release}}-winsetup.exe/download))
+, along with 
+[docs](https://sourceforge.net/projects/geoserver/files/GeoServer/{{release}}/geoserver-{{release}}-htmldoc.zip/download) and
+[extensions](https://sourceforge.net/projects/geoserver/files/GeoServer/{{release}}/extensions/).
+
+{% block description %}
+{% endblock %}
+
+{%- if dependency is defined and dependency|length > 0 -%}
+GeoServer {{name}} is made in conjunction with 
+   {%- for project,version in dependency -%}
+      {%- if loop.index0 != 0 -%}
+      , 
+      {%- endif %}
+      {%- if loop.index == dependency|length and dependency|length > 1 %}
+ and 
+      {%- endif %}
+ {{project}} {{version}}
+   {%- endfor -%}
+. 
+{% endif %}
+
+Thanks to {{author}} for making this release.

--- a/bin/templates/archive.md
+++ b/bin/templates/archive.md
@@ -1,0 +1,5 @@
+{% extends 'announcement.md' %}
+
+{% block description %}
+This series has previously reached end-of-life, and being issued to address an urgent bug or security vulnerability. Please apply this update as a mitigation measure only, and plan to upgrade to a stable or maintenance release of GeoServer.
+{% endblock %}

--- a/bin/templates/header.md
+++ b/bin/templates/header.md
@@ -1,0 +1,21 @@
+---
+author: {{author}}
+date: {{releaseVersion.releaseDate}}
+layout: post
+title: GeoServer {{name}} Release
+categories:
+- Announcements
+tags:
+- Release
+{% if series == 'release candidate' %}
+- Release Candidate
+{% elif series == 'milestone' %}
+- Milestone Release
+{% endif %}
+{% if vulnerability %}
+- Vulnerability
+{% endif %}
+release: release_{{name[0:1]}}{{name[2:4]}}
+version: {{name}}
+jira_version: {{releaseVersion.id}}
+---

--- a/bin/templates/maintenance.md
+++ b/bin/templates/maintenance.md
@@ -1,0 +1,5 @@
+{% extends 'announcement.md' %}
+
+{% block description %}
+This is a maintenance release of GeoServer providing a existing installations with minor updates and bug fixes.
+{% endblock %}

--- a/bin/templates/milestone.md
+++ b/bin/templates/milestone.md
@@ -1,0 +1,5 @@
+{% extends 'announcement.md' %}
+
+{% block description %}
+This is a milestone release previewing GeoServer {{release[0:4]}} for public feedback.
+{% endblock %}

--- a/bin/templates/release-candidate.md
+++ b/bin/templates/release-candidate.md
@@ -1,0 +1,5 @@
+{% extends 'announcement.md' %}
+
+{% block description %}
+This is a release candidate intended for public review and feedback.
+{% endblock %}

--- a/bin/templates/release_notes.md
+++ b/bin/templates/release_notes.md
@@ -1,0 +1,13 @@
+## Release notes
+{% for issueTypeName in issueTypeNames %}
+
+{{issueTypeName}}:
+
+   {% for issue in projectIssues.issues %}
+      {% if issue.fields.issuetype.name == issueTypeName %}
+* [{{ issue.key }}]({{ jiraBaseUrl }}/browse/{{ issue.key }}) {{ issue.fields.summary }}
+      {% endif %}    
+   {%- endfor %}
+{%- endfor %}
+
+For the complete list see [{{ release.name }}](https://github.com/geoserver/geoserver/releases/tag/{{ release.name }}) release notes.

--- a/bin/templates/security.md
+++ b/bin/templates/security.md
@@ -1,0 +1,10 @@
+## Security Considerations
+
+This release addresses security vulnerabilities and is considered an essential upgrade for production systems.
+
+{% for issue in vulnerabilities %}
+* [{{ issue.key }}]({{ jiraBaseUrl }}/browse/{{ issue.key }}) {{ issue.fields.summary }}
+{%- endfor %}
+
+
+See project [security policy](https://github.com/geoserver/geoserver/blob/main/SECURITY.md) for more information on how security vulnerabilities are managed.

--- a/bin/templates/stable.md
+++ b/bin/templates/stable.md
@@ -1,0 +1,5 @@
+{% extends 'announcement.md' %}
+
+{% block description %}
+This is a stable release of GeoServer recommended production use.
+{% endblock %}


### PR DESCRIPTION
Forgive the python but it does the trick, ...

Preview using:
```
cd bin
python3 anouncement.py username password 2.23.2
```

Generate using:
```
python3 anouncement.py username password 2.23.2 -post
```

The announcement text (release candidate, milestone, stable, release) is determined based on the version number (override with ``-stable`` and ``-maintenance`` command line options).

Use the ``-security`` command line option to include the security vulnerability blurb, and update the document header tags.