### PR TITLE
{{name}} is undefined in template.render, switch to {{release}}

### DIFF
--- a/bin/templates/announcement.md
+++ b/bin/templates/announcement.md
@@ -10,7 +10,7 @@ with downloads
 {% endblock %}
 
 {%- if dependency is defined and dependency|length > 0 -%}
-GeoServer {{name}} is made in conjunction with 
+GeoServer {{release}} is made in conjunction with 
    {%- for project,version in dependency -%}
       {%- if loop.index0 != 0 -%}
       , 


### PR DESCRIPTION
Used to result in:

> GeoServer  is made in conjunction with GeoTools 29.3, and GeoWebCache 1.23.2.

Now: 

> GeoServer 2.23.3 is made in conjunction with GeoTools 29.3, and GeoWebCache 1.23.2.