### PR TITLE
Release announcement updates providing active links for disclosed vulnerabilities

### DIFF
--- a/_posts/2020-09-26-geoserver-2-18-0-released.md
+++ b/_posts/2020-09-26-geoserver-2-18-0-released.md
@@ -31,6 +31,16 @@ We would like to thank everyone who contributed to this release, and helped with
 
 Thanks to Jukka Rahkonen, Jody Garnett and Brad Hards for initial testing of this release. This release was carried out by Ian Turton of Astun Technology and the support of the UK Hydrographic Office.
 
+### Security Considerations
+
+**2024-06-30 Update:** The following mitigation has been provided:
+
+* [CVE-2024-36401](https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv) Remote Code Execution (RCE) vulnerability in evaluating property name expressions
+
+  A [patch](https://sourceforge.net/projects/geoserver/files/GeoServer/2.18.0/geoserver-2.18.0-patches.zip/download) (replacing `gt-app-schema`, `gt-complex` and `gt-xsd-core` jars) has been provided by Andrea (GeoSolutions)
+
+See project [security policy](https://github.com/geoserver/geoserver/blob/main/SECURITY.md) for more information on how security vulnerabilities are managed. 
+
 ### Black Lives Matter
 
 The casual use of the word "slave" in computer software is an unnecessary

--- a/_posts/2020-09-26-geoserver-2-18-0-released.md
+++ b/_posts/2020-09-26-geoserver-2-18-0-released.md
@@ -35,7 +35,7 @@ Thanks to Jukka Rahkonen, Jody Garnett and Brad Hards for initial testing of thi
 
 **2024-06-30 Update:** The following mitigation has been provided:
 
-* [CVE-2024-36401](https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv) Remote Code Execution (RCE) vulnerability in evaluating property name expressions
+* [CVE-2024-36401](https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv) Remote Code Execution (RCE) vulnerability in evaluating property name expressions (Critical)
 
   A [patch](https://sourceforge.net/projects/geoserver/files/GeoServer/2.18.0/geoserver-2.18.0-patches.zip/download) (replacing `gt-app-schema`, `gt-complex` and `gt-xsd-core` jars) has been provided by Andrea (GeoSolutions)
 

--- a/_posts/2021-07-18-geoserver-2-19-2-released.md
+++ b/_posts/2021-07-18-geoserver-2-19-2-released.md
@@ -17,6 +17,14 @@ This GeoServer 2.19.2 release was produced in conjunction with GeoTools 25.2, th
 
 Thanks to everyone who contributed, and to Jody Garnett (GeoCat) for making this release.
 
+## Security Considerations
+
+**2024-0601 Update:** Although this branch has reached end-of-life a [patch](https://sourceforge.net/projects/geoserver/files/GeoServer/2.19.2/geoserver-2.19.2-patches.zip/download) for this release has been provided by Andrea (GeoSolutions) in support of their customers:
+
+* [CVE-2024-36401](https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv) Remote Code Execution (RCE) vulnerability in evaluating property name expressions
+
+This patch replaces the **gt-app-schema**, **gt-complex** and **gt-xsd-core** jars.
+
 ## Improvements and Fixes
 
 New features are included in this release:

--- a/_posts/2022-04-11-geoserver-2-20-4-released.md
+++ b/_posts/2022-04-11-geoserver-2-20-4-released.md
@@ -38,7 +38,7 @@ This release also includes:
 
 **2024-06-30 Update:** The following mitigation has been provided:
 
-* [CVE-2024-36401](https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv) Remote Code Execution (RCE) vulnerability in evaluating property name expressions
+* [CVE-2024-36401](https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv) Remote Code Execution (RCE) vulnerability in evaluating property name expressions (Critical)
 
   A [patch](https://sourceforge.net/projects/geoserver/files/GeoServer/2.20.4/geoserver-2.20.4-patches.zip/download) (replacing `gt-app-schema`, `gt-complex` and `gt-xsd-core` jars) has been provided by Andrea (GeoSolutions)
 

--- a/_posts/2022-04-11-geoserver-2-20-4-released.md
+++ b/_posts/2022-04-11-geoserver-2-20-4-released.md
@@ -29,13 +29,20 @@ This release includes two improvements addressing [Jiffle and GeoTools RCE vulne
 * [GEOS-10458](https://osgeo-org.atlassian.net/browse/GEOS-10458) Upgrade to JAI-EXT 1.1.22
 
 * [GEOT-7115](https://osgeo-org.atlassian.net/browse/GEOT-7115) Streamline JNDI lookups
-  
- 
+
 This release also includes:
 
 * [GEOS-10445](https://osgeo-org.atlassian.net/browse/GEOS-10445) Upgrade springframework from 5.1.20.RELEASE to 5.2.20.RELEASE
   
   Although GeoServer [assessment]({% post_url 2022-04-01-spring %}) did not identify any issue we have now updated the the spring framework library.
+
+**2024-06-30 Update:** The following mitigation has been provided:
+
+* [CVE-2024-36401](https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv) Remote Code Execution (RCE) vulnerability in evaluating property name expressions
+
+  A [patch](https://sourceforge.net/projects/geoserver/files/GeoServer/2.20.4/geoserver-2.20.4-patches.zip/download) (replacing `gt-app-schema`, `gt-complex` and `gt-xsd-core` jars) has been provided by Andrea (GeoSolutions)
+
+See project [security policy](https://github.com/geoserver/geoserver/blob/main/SECURITY.md) for more information on how security vulnerabilities are managed. 
 
 ### Add Styles support to LayerGroup
 

--- a/_posts/2023-02-20-geoserver-2-20-7-released.md
+++ b/_posts/2023-02-20-geoserver-2-20-7-released.md
@@ -34,6 +34,15 @@ For more information see [OGC Filter Injection Vulnerability Statement]({% post_
 * [GEOS-10842 JDBCConfig: escape user inputs in SQL queries](https://osgeo-org.atlassian.net/browse/GEOS-10842)
 * [GEOS-10839 JDBCConfig: add JDBC Configuration parameter to disable SQL comments and pretty-printing](https://osgeo-org.atlassian.net/browse/GEOS-10839)
 
+**2024-06-30 Update:** The following mitigation has been provided:
+
+* [CVE-2024-36401](https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv) Remote Code Execution (RCE) vulnerability in evaluating property name expressions
+
+  A [patch](https://sourceforge.net/projects/geoserver/files/GeoServer/2.20.7/geoserver-2.20.7-patches.zip/download) (replacing `gt-app-schema`, `gt-complex` and `gt-xsd-core` jars) has been provided by Andrea (GeoSolutions)
+
+See project [security policy](https://github.com/geoserver/geoserver/blob/main/SECURITY.md) for more information on how security vulnerabilities are managed. .
+
+
 ### Improvements and Fixes
 
 For the full list of fixes and improvements, see [2.20.7 release notes](https://github.com/geoserver/geoserver/releases/tag/2.20.7).

--- a/_posts/2023-02-20-geoserver-2-20-7-released.md
+++ b/_posts/2023-02-20-geoserver-2-20-7-released.md
@@ -36,7 +36,7 @@ For more information see [OGC Filter Injection Vulnerability Statement]({% post_
 
 **2024-06-30 Update:** The following mitigation has been provided:
 
-* [CVE-2024-36401](https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv) Remote Code Execution (RCE) vulnerability in evaluating property name expressions
+* [CVE-2024-36401](https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv) Remote Code Execution (RCE) vulnerability in evaluating property name expressions (Critical)
 
   A [patch](https://sourceforge.net/projects/geoserver/files/GeoServer/2.20.7/geoserver-2.20.7-patches.zip/download) (replacing `gt-app-schema`, `gt-complex` and `gt-xsd-core` jars) has been provided by Andrea (GeoSolutions)
 

--- a/_posts/2023-02-20-geoserver-2-21-4-released.md
+++ b/_posts/2023-02-20-geoserver-2-21-4-released.md
@@ -34,7 +34,7 @@ For more information see [OGC Filter Injection Vulnerability Statement]({% post_
 
 **2024-06-30 Update:** The following mitigation has been provided:
 
-* [CVE-2024-36401](https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv) Remote Code Execution (RCE) vulnerability in evaluating property name expressions
+* [CVE-2024-36401](https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv) Remote Code Execution (RCE) vulnerability in evaluating property name expressions (Critical)
 
   A [patch](https://sourceforge.net/projects/geoserver/files/GeoServer/2.21.4/geoserver-2.21.4-patches.zip/download) (replacing `gt-app-schema`, `gt-complex` and `gt-xsd-core` jars) has been provided by Andrea (GeoSolutions)
 

--- a/_posts/2023-02-20-geoserver-2-21-4-released.md
+++ b/_posts/2023-02-20-geoserver-2-21-4-released.md
@@ -32,6 +32,14 @@ For more information see [OGC Filter Injection Vulnerability Statement]({% post_
 * [GEOS-10842 JDBCConfig: escape user inputs in SQL queries](https://osgeo-org.atlassian.net/browse/GEOS-10842)
 * [GEOS-10839 JDBCConfig: add JDBC Configuration parameter to disable SQL comments and pretty-printing](https://osgeo-org.atlassian.net/browse/GEOS-10839)
 
+**2024-06-30 Update:** The following mitigation has been provided:
+
+* [CVE-2024-36401](https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv) Remote Code Execution (RCE) vulnerability in evaluating property name expressions
+
+  A [patch](https://sourceforge.net/projects/geoserver/files/GeoServer/2.21.4/geoserver-2.21.4-patches.zip/download) (replacing `gt-app-schema`, `gt-complex` and `gt-xsd-core` jars) has been provided by Andrea (GeoSolutions)
+
+See project [security policy](https://github.com/geoserver/geoserver/blob/main/SECURITY.md) for more information on how security vulnerabilities are managed. 
+
 ### Community Modules
 
 The JDBC Config module received several important fixes:

--- a/_posts/2023-02-20-geoserver-2-22-2-released.md
+++ b/_posts/2023-02-20-geoserver-2-22-2-released.md
@@ -31,7 +31,15 @@ For more information see [OGC Filter Injection Vulnerability Statement]({% post_
 * [GEOT-7302 Escape user inputs in SQL queries](https://osgeo-org.atlassian.net/browse/GEOT-7302)
 * [GEOS-10842 JDBCConfig: escape user inputs in SQL queries](https://osgeo-org.atlassian.net/browse/GEOS-10842)
 * [GEOS-10839 JDBCConfig: add JDBC Configuration parameter to disable SQL comments and pretty-printing](https://osgeo-org.atlassian.net/browse/GEOS-10839)
-  
+
+**2024-06-30 Update:** The following mitigation has been provided:
+
+* [CVE-2024-36401](https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv) Remote Code Execution (RCE) vulnerability in evaluating property name expressions
+
+  A [patch](https://sourceforge.net/projects/geoserver/files/GeoServer/2.22.2/geoserver-2.22.2-patches.zip/download) (replacing `gt-app-schema`, `gt-complex` and `gt-xsd-core` jars) has been provided by Andrea (GeoSolutions)
+
+See project [security policy](https://github.com/geoserver/geoserver/blob/main/SECURITY.md) for more information on how security vulnerabilities are managed. 
+
 ### Natural Earth 50m Sample Data
 
 The Natural Earth ``ne`` workspace has been improved with 1:50m sample data offering the following:

--- a/_posts/2023-02-20-geoserver-2-22-2-released.md
+++ b/_posts/2023-02-20-geoserver-2-22-2-released.md
@@ -34,7 +34,7 @@ For more information see [OGC Filter Injection Vulnerability Statement]({% post_
 
 **2024-06-30 Update:** The following mitigation has been provided:
 
-* [CVE-2024-36401](https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv) Remote Code Execution (RCE) vulnerability in evaluating property name expressions
+* [CVE-2024-36401](https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv) Remote Code Execution (RCE) vulnerability in evaluating property name expressions (Critical)
 
   A [patch](https://sourceforge.net/projects/geoserver/files/GeoServer/2.22.2/geoserver-2.22.2-patches.zip/download) (replacing `gt-app-schema`, `gt-complex` and `gt-xsd-core` jars) has been provided by Andrea (GeoSolutions)
 

--- a/_posts/2023-05-08-geoserver-2-21-5-released.md
+++ b/_posts/2023-05-08-geoserver-2-21-5-released.md
@@ -19,6 +19,16 @@ and GeoWebCache 1.21.5.
 
 Thanks to Daniele Romagnoli (GeoSolutions) for making this release.
 
+### Security Considerations
+
+**2024-06-30 Update:** The following mitigation has been provided:
+
+* [CVE-2024-36401](https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv) Remote Code Execution (RCE) vulnerability in evaluating property name expressions
+
+  A [patch](https://sourceforge.net/projects/geoserver/files/GeoServer/2.21.5/geoserver-2.21.5-patches.zip/download) (replacing `gt-app-schema`, `gt-complex` and `gt-xsd-core` jars) has been provided by Andrea (GeoSolutions)
+
+See project [security policy](https://github.com/geoserver/geoserver/blob/main/SECURITY.md) for more information on how security vulnerabilities are managed. 
+
 ### Release notes
 
 Bug

--- a/_posts/2023-05-08-geoserver-2-21-5-released.md
+++ b/_posts/2023-05-08-geoserver-2-21-5-released.md
@@ -23,7 +23,7 @@ Thanks to Daniele Romagnoli (GeoSolutions) for making this release.
 
 **2024-06-30 Update:** The following mitigation has been provided:
 
-* [CVE-2024-36401](https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv) Remote Code Execution (RCE) vulnerability in evaluating property name expressions
+* [CVE-2024-36401](https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv) Remote Code Execution (RCE) vulnerability in evaluating property name expressions (Critical)
 
   A [patch](https://sourceforge.net/projects/geoserver/files/GeoServer/2.21.5/geoserver-2.21.5-patches.zip/download) (replacing `gt-app-schema`, `gt-complex` and `gt-xsd-core` jars) has been provided by Andrea (GeoSolutions)
 

--- a/_posts/2024-01-24-geoserver-2-24-2-released.md
+++ b/_posts/2024-01-24-geoserver-2-24-2-released.md
@@ -32,8 +32,13 @@ This release addresses security vulnerabilities and is considered an essential u
 
 - [CVE-2024-23634](https://github.com/geoserver/geoserver/security/advisories/GHSA-75m5-hh4r-q9gx) Arbitrary file renaming vulnerability in REST Coverage/Data Store API (Moderate).
 
-See project [security policy](https://github.com/geoserver/geoserver/blob/main/SECURITY.md) for more information on how security vulnerabilities are managed.
+**2024-06-30 Update:** The following mitigation has been provided:
 
+* [CVE-2024-36401](https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv) Remote Code Execution (RCE) vulnerability in evaluating property name expressions
+
+  A [patch](https://sourceforge.net/projects/geoserver/files/GeoServer/2.24.2/geoserver-2.24.2-patches.zip/download) (replacing `gt-app-schema`, `gt-complex` and `gt-xsd-core` jars) has been provided by Andrea (GeoSolutions)
+
+See project [security policy](https://github.com/geoserver/geoserver/blob/main/SECURITY.md) for more information on how security vulnerabilities are managed. 
 
 ## Release notes
 

--- a/_posts/2024-01-24-geoserver-2-24-2-released.md
+++ b/_posts/2024-01-24-geoserver-2-24-2-released.md
@@ -34,7 +34,7 @@ This release addresses security vulnerabilities and is considered an essential u
 
 **2024-06-30 Update:** The following mitigation has been provided:
 
-* [CVE-2024-36401](https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv) Remote Code Execution (RCE) vulnerability in evaluating property name expressions
+* [CVE-2024-36401](https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv) Remote Code Execution (RCE) vulnerability in evaluating property name expressions (Critical)
 
   A [patch](https://sourceforge.net/projects/geoserver/files/GeoServer/2.24.2/geoserver-2.24.2-patches.zip/download) (replacing `gt-app-schema`, `gt-complex` and `gt-xsd-core` jars) has been provided by Andrea (GeoSolutions)
 

--- a/_posts/2024-02-18-geoserver-2-23-5-released.md
+++ b/_posts/2024-02-18-geoserver-2-23-5-released.md
@@ -32,7 +32,7 @@ Thanks to Andrea Aime (GeoSolutions) for making this release.
 
 This release addresses security vulnerabilities and is considered an essential upgrade for production systems.
 
-- [CVE-2024-23634](https://github.com/geoserver/geoserver/security/advisories/GHSA-75m5-hh4r-q9gx) Arbitrary file renaming vulnerability in REST Coverage/Data Store API (Moderate).
+- [CVE-2024-23634](https://github.com/geoserver/geoserver/security/advisories/GHSA-75m5-hh4r-q9gx) Arbitrary file renaming vulnerability in REST Coverage/Data Store API (Moderate)
 
 See project [security policy](https://github.com/geoserver/geoserver/blob/main/SECURITY.md) for more information on how security vulnerabilities are managed.
 

--- a/_posts/2024-03-19-geoserver-2-25-0-released.md
+++ b/_posts/2024-03-19-geoserver-2-25-0-released.md
@@ -45,6 +45,7 @@ Vulnerabilities:
 - [CVE-2024-23642](https://github.com/geoserver/geoserver/security/advisories/GHSA-fg9v-56hw-g525) Stored Cross-Site Scripting (XSS) vulnerability in Simple SVG Renderer (Moderate).
 - [CVE-2024-23640](https://github.com/geoserver/geoserver/security/advisories/GHSA-9rfr-pf2x-g4xf) Stored Cross-Site Scripting (XSS) vulnerability in Style Publisher (Moderate).
 - [CVE-2023-51445](https://github.com/geoserver/geoserver/security/advisories/GHSA-fh7p-5f6g-vj2w) Stored Cross-Site Scripting (XSS) vulnerability in REST Resources API (Moderate).
+- CVE-2024-34711 High
 
 We would like to thank everyone who contributed to reporting, verifying and fixing the above vulnerabilities (see each CVE for appropriate credits). A special thank you to Steve Ikeoka for reporting most of the issues and doing the majority of the actual fixes. 
 

--- a/_posts/2024-03-19-geoserver-2-25-0-released.md
+++ b/_posts/2024-03-19-geoserver-2-25-0-released.md
@@ -45,7 +45,7 @@ Vulnerabilities:
 - [CVE-2024-23642](https://github.com/geoserver/geoserver/security/advisories/GHSA-fg9v-56hw-g525) Stored Cross-Site Scripting (XSS) vulnerability in Simple SVG Renderer (Moderate).
 - [CVE-2024-23640](https://github.com/geoserver/geoserver/security/advisories/GHSA-9rfr-pf2x-g4xf) Stored Cross-Site Scripting (XSS) vulnerability in Style Publisher (Moderate).
 - [CVE-2023-51445](https://github.com/geoserver/geoserver/security/advisories/GHSA-fh7p-5f6g-vj2w) Stored Cross-Site Scripting (XSS) vulnerability in REST Resources API (Moderate).
-- CVE-2024-34711 High
+- CVE-2024-34711 (High)
 
 We would like to thank everyone who contributed to reporting, verifying and fixing the above vulnerabilities (see each CVE for appropriate credits). A special thank you to Steve Ikeoka for reporting most of the issues and doing the majority of the actual fixes. 
 

--- a/_posts/2024-04-18-geoserver-2-24-3-released.md
+++ b/_posts/2024-04-18-geoserver-2-24-3-released.md
@@ -25,6 +25,17 @@ GeoServer 2.24.3 is made in conjunction with GeoTools 30.3, and GeoWebCache 1.24
 
 Thanks to Andrea Aime (GeoSolutions) for making this release.
 
+### Security Considerations
+
+**2024-06-30 Update:** The following mitigation has been provided:
+
+* [CVE-2024-36401](https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv) Remote Code Execution (RCE) vulnerability in evaluating property name expressions
+
+  A [patch](https://sourceforge.net/projects/geoserver/files/GeoServer/2.24.3/geoserver-2.24.3-patches.zip/download) (replacing `gt-app-schema`, `gt-complex` and `gt-xsd-core` jars) has been provided by Andrea (GeoSolutions)
+
+See project [security policy](https://github.com/geoserver/geoserver/blob/main/SECURITY.md) for more information on how security vulnerabilities are managed. 
+
+
 ## Release notes
 
 New Feature:

--- a/_posts/2024-04-18-geoserver-2-24-3-released.md
+++ b/_posts/2024-04-18-geoserver-2-24-3-released.md
@@ -29,7 +29,7 @@ Thanks to Andrea Aime (GeoSolutions) for making this release.
 
 **2024-06-30 Update:** The following mitigation has been provided:
 
-* [CVE-2024-36401](https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv) Remote Code Execution (RCE) vulnerability in evaluating property name expressions
+* [CVE-2024-36401](https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv) Remote Code Execution (RCE) vulnerability in evaluating property name expressions (Critical)
 
   A [patch](https://sourceforge.net/projects/geoserver/files/GeoServer/2.24.3/geoserver-2.24.3-patches.zip/download) (replacing `gt-app-schema`, `gt-complex` and `gt-xsd-core` jars) has been provided by Andrea (GeoSolutions)
 

--- a/_posts/2024-05-23-geoserver-2-25-1-released.md
+++ b/_posts/2024-05-23-geoserver-2-25-1-released.md
@@ -31,7 +31,13 @@ Thanks to Jody Garnett (GeoCat) for making this release.
 
 This release addresses security vulnerabilities and is considered an essential upgrade for production systems.
 
-See project [security policy](https://github.com/geoserver/geoserver/blob/main/SECURITY.md) for more information on how security vulnerabilities are managed. 
+**2024-06-30 Update:** The following mitigation has been provided:
+
+* [CVE-2024-36401](https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv) Remote Code Execution (RCE) vulnerability in evaluating property name expressions
+
+  A [patch](https://sourceforge.net/projects/geoserver/files/GeoServer/2.25.1/geoserver-2.25.1-patches.zip/download) (replacing `gt-app-schema`, `gt-complex` and `gt-xsd-core` jars) has been provided by Andrea (GeoSolutions)
+
+See project [security policy](https://github.com/geoserver/geoserver/blob/main/SECURITY.md) for more information on how security vulnerabilities are managed.
 
 ## Raster Attribute Table Extension
 

--- a/_posts/2024-05-23-geoserver-2-25-1-released.md
+++ b/_posts/2024-05-23-geoserver-2-25-1-released.md
@@ -33,7 +33,7 @@ This release addresses security vulnerabilities and is considered an essential u
 
 **2024-06-30 Update:** The following mitigation has been provided:
 
-* [CVE-2024-36401](https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv) Remote Code Execution (RCE) vulnerability in evaluating property name expressions
+* [CVE-2024-36401](https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv) Remote Code Execution (RCE) vulnerability in evaluating property name expressions (Critical)
 
   A [patch](https://sourceforge.net/projects/geoserver/files/GeoServer/2.25.1/geoserver-2.25.1-patches.zip/download) (replacing `gt-app-schema`, `gt-complex` and `gt-xsd-core` jars) has been provided by Andrea (GeoSolutions)
 

--- a/_posts/2024-06-13-geoserver-2-23-6-released.md
+++ b/_posts/2024-06-13-geoserver-2-23-6-released.md
@@ -33,8 +33,8 @@ Thanks to Jody Garnett (GeoCat) for making this release on behalf of GeoCat cust
 
 This release addresses security vulnerabilities and is considered an essential update for production systems.
 
-* [CVE-2024-36401](https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv) Remote Code Execution (RCE) vulnerability in evaluating property name expressions
-* [CVE-2024-24749](https://github.com/geoserver/geoserver/security/advisories/GHSA-jhqx-5v5g-mpf3) Classpath resource disclosure in GWC Web Resource API on Windows / Tomcat
+* [CVE-2024-36401](https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv) Remote Code Execution (RCE) vulnerability in evaluating property name expressions (Critical)
+* [CVE-2024-24749](https://github.com/geoserver/geoserver/security/advisories/GHSA-jhqx-5v5g-mpf3) Classpath resource disclosure in GWC Web Resource API on Windows / Tomcat (Moderate)
 
 See project [security policy](https://github.com/geoserver/geoserver/blob/main/SECURITY.md) for more information on how security vulnerabilities are managed.
 

--- a/_posts/2024-06-13-geoserver-2-23-6-released.md
+++ b/_posts/2024-06-13-geoserver-2-23-6-released.md
@@ -33,10 +33,8 @@ Thanks to Jody Garnett (GeoCat) for making this release on behalf of GeoCat cust
 
 This release addresses security vulnerabilities and is considered an essential update for production systems.
 
-* CVE-2024-36401 Critical
-* CVE-2024-24749 Moderate
-
-The details of this vulnerability will be made available at the end of the month providing an opportunity to update.
+* [CVE-2024-36401](https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv) Remote Code Execution (RCE) vulnerability in evaluating property name expressions
+* [CVE-2024-24749](https://github.com/geoserver/geoserver/security/advisories/GHSA-jhqx-5v5g-mpf3) Classpath resource disclosure in GWC Web Resource API on Windows / Tomcat
 
 See project [security policy](https://github.com/geoserver/geoserver/blob/main/SECURITY.md) for more information on how security vulnerabilities are managed.
 

--- a/_posts/2024-06-18-geoserver-2-24-4-released.md
+++ b/_posts/2024-06-18-geoserver-2-24-4-released.md
@@ -31,9 +31,9 @@ Thanks to Peter Smythe (AfriGIS) for making this release.
 
 This release addresses security vulnerabilities and is considered an essential upgrade for production systems.
 
-* [CVE-2024-36401](https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv) Remote Code Execution (RCE) vulnerability in evaluating property name expressions
-* [CVE-2024-24749](https://github.com/geoserver/geoserver/security/advisories/GHSA-jhqx-5v5g-mpf3) Classpath resource disclosure in GWC Web Resource API on Windows / Tomcat
-* [CVE-2024-34696](https://github.com/geoserver/geoserver/security/advisories/GHSA-j59v-vgcr-hxvf) GeoServer About Status lists sensitive Environmental Variables
+* [CVE-2024-36401](https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv) Remote Code Execution (RCE) vulnerability in evaluating property name expressions (Critical)
+* [CVE-2024-24749](https://github.com/geoserver/geoserver/security/advisories/GHSA-jhqx-5v5g-mpf3) Classpath resource disclosure in GWC Web Resource API on Windows / Tomcat (Moderate)
+* [CVE-2024-34696](https://github.com/geoserver/geoserver/security/advisories/GHSA-j59v-vgcr-hxvf) GeoServer About Status lists sensitive Environmental Variables (Moderate)
 
 The use of the CVE system allows the GeoServer team to reach a wider audience than blog posts.  See project [security policy](https://github.com/geoserver/geoserver/blob/main/SECURITY.md) for more information on how security vulnerabilities are managed.
 

--- a/_posts/2024-06-18-geoserver-2-24-4-released.md
+++ b/_posts/2024-06-18-geoserver-2-24-4-released.md
@@ -31,11 +31,9 @@ Thanks to Peter Smythe (AfriGIS) for making this release.
 
 This release addresses security vulnerabilities and is considered an essential upgrade for production systems.
 
-* CVE-2024-36401 Critical
-* CVE-2024-34696 Moderate
-* CVE-2024-24749 Moderate
-
-The details of this vulnerability will be made available at the end of the month providing an opportunity to update.
+* [CVE-2024-36401](https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv) Remote Code Execution (RCE) vulnerability in evaluating property name expressions
+* [CVE-2024-24749](https://github.com/geoserver/geoserver/security/advisories/GHSA-jhqx-5v5g-mpf3) Classpath resource disclosure in GWC Web Resource API on Windows / Tomcat
+* [CVE-2024-34696](https://github.com/geoserver/geoserver/security/advisories/GHSA-j59v-vgcr-hxvf) GeoServer About Status lists sensitive Environmental Variables
 
 The use of the CVE system allows the GeoServer team to reach a wider audience than blog posts.  See project [security policy](https://github.com/geoserver/geoserver/blob/main/SECURITY.md) for more information on how security vulnerabilities are managed.
 

--- a/_posts/2024-06-18-geoserver-2-25-2-released.md
+++ b/_posts/2024-06-18-geoserver-2-25-2-released.md
@@ -30,9 +30,9 @@ Thanks to Jody Garnett (GeoCat) for making this release on behalf of GeoCat cust
 
 This release addresses security vulnerabilities and is considered an essential upgrade for production systems.
 
-* [CVE-2024-36401](https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv) Remote Code Execution (RCE) vulnerability in evaluating property name expressions
-* [CVE-2024-24749](https://github.com/geoserver/geoserver/security/advisories/GHSA-jhqx-5v5g-mpf3) Classpath resource disclosure in GWC Web Resource API on Windows / Tomcat
-* [CVE-2024-34696](https://github.com/geoserver/geoserver/security/advisories/GHSA-j59v-vgcr-hxvf) GeoServer About Status lists sensitive Environmental Variables
+* [CVE-2024-36401](https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv) Remote Code Execution (RCE) vulnerability in evaluating property name expressions (Critical)
+* [CVE-2024-24749](https://github.com/geoserver/geoserver/security/advisories/GHSA-jhqx-5v5g-mpf3) Classpath resource disclosure in GWC Web Resource API on Windows / Tomcat (Moderate)
+* [CVE-2024-34696](https://github.com/geoserver/geoserver/security/advisories/GHSA-j59v-vgcr-hxvf) GeoServer About Status lists sensitive Environmental Variables (Moderate)
 * CVE-2024-35230 Moderate
 
 The use of the CVE system allows the GeoServer team to reach a wider audience than blog posts. See the project [security policy](https://github.com/geoserver/geoserver/blob/main/SECURITY.md) for more information on how security vulnerabilities are managed.

--- a/_posts/2024-06-18-geoserver-2-25-2-released.md
+++ b/_posts/2024-06-18-geoserver-2-25-2-released.md
@@ -30,12 +30,10 @@ Thanks to Jody Garnett (GeoCat) for making this release on behalf of GeoCat cust
 
 This release addresses security vulnerabilities and is considered an essential upgrade for production systems.
 
-* CVE-2024-36401 Critical
-* CVE-2024-34696 Moderate
+* [CVE-2024-36401](https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv) Remote Code Execution (RCE) vulnerability in evaluating property name expressions
+* [CVE-2024-24749](https://github.com/geoserver/geoserver/security/advisories/GHSA-jhqx-5v5g-mpf3) Classpath resource disclosure in GWC Web Resource API on Windows / Tomcat
+* [CVE-2024-34696](https://github.com/geoserver/geoserver/security/advisories/GHSA-j59v-vgcr-hxvf) GeoServer About Status lists sensitive Environmental Variables
 * CVE-2024-35230 Moderate
-* CVE-2024-24749 Moderate
-
-The details of this vulnerability will be made available at the end of the month providing an opportunity to update.
 
 The use of the CVE system allows the GeoServer team to reach a wider audience than blog posts. See the project [security policy](https://github.com/geoserver/geoserver/blob/main/SECURITY.md) for more information on how security vulnerabilities are managed.
 


### PR DESCRIPTION
The vulnerabilities have been published via GitHub security advisory database thing ... this PR provides links to prior release announcements.

It was a bit tricky to word the update for "patches" provided for prior releases, but I think the result is clear.