### PR TITLE
IAU extension missing from 2.25.x, RAT extension missing for versions >= 2.25.1

### DIFF
--- a/_layouts/release_225.html
+++ b/_layouts/release_225.html
@@ -225,6 +225,12 @@
                   <li><a dl="web-resource-plugin">Resource Browser Tool</a></li>
                   <li><a dl="gwc-s3-plugin">GWC S3 tile storage</a></li>
                   <li><a dl="params-extractor-plugin">Request parameters extractor</a></li>
+                  <li><a dl="iau-plugin">International Astronomical Union CRS authority</a></li>
+                  {% assign version_parts = page.version | split: '.' %}
+                  {% assign version_minor = version_parts[2] | plus: '0' %}
+                  {% if version_minor >= 1 %}
+                  <li><a dl="rat-plugin">Raster Attribute Table plugin</a></li>
+                  {% endif %}
                 </ul>
                 <h4>Security</h4>
                 <ul>


### PR DESCRIPTION
Small bit of conditional in the 2.25.x template to handle the RAT plugin not being in 2.25.0, could be useful later.