### PR TITLE
CVE-2024-45748 is not ready to be disclosed

### DIFF
--- a/_posts/2024-09-18-geoserver-2-26-0-released.md
+++ b/_posts/2024-09-18-geoserver-2-26-0-released.md
@@ -39,7 +39,6 @@ Thanks to Daniel Calliess for responding during our public testing cycle. Daniel
 
 This release addresses security vulnerabilities and is a recommended upgrade for production systems.
 
-* CVE-2024-45748 High (to be disclosed)
 * [CVE-2024-34711](https://github.com/geoserver/geoserver/security/advisories/GHSA-mc43-4fqr-c965) Improper ENTITY_RESOLUTION_ALLOWLIST URI validation in XML Processing (SSRF) (High 7.3)
 * [CVE-2024-35230](https://github.com/geoserver/geoserver/security/advisories/GHSA-6pfc-w86r-54q6): Welcome and About GeoServer pages communicate version and revision information (Moderate 5.3)
 


### PR DESCRIPTION
Mitigation for 2.22.0 onward is in place (with some loss of functioanlity), but fix is not yet available.

For more information see [GHSA-4w7r-5vv8-fx9j](https://github.com/geoserver/geoserver/security/advisories/GHSA-4w7r-5vv8-fx9j)