### PR TITLE
Fix link to wiki new feature page

### DIFF
--- a/roadmap/index.html
+++ b/roadmap/index.html
@@ -36,7 +36,7 @@ Please see the wiki <a href="{{ site.wiki_url }}/Release-Schedule">GeoTools and 
 <section>
 <p>
 The future direction of GeoServer is primarily shaped by the constant flow of code contributions and funding directed towards the implementation of new features.
-In case you are wondering about a new feature or improvement we have a <a href="{{ site.wiki_url }}/Successfully-requesting-and-integrating-new-features-and-improvements-in-GeoServer" >wiki page describing the process to discuss and implement it</a>.
+In case you are wondering about a new feature or improvement we have a <a href="{{ site.wiki_url }}/Successfully-requesting-and-integrating-fixes,-improvements-and-new-features-in-GeoServer,-GeoTools-and-GeoWebCache" >wiki page describing the process to discuss and implement it</a>.
 </p>
 </section>
 

--- a/roadmap/index.html
+++ b/roadmap/index.html
@@ -36,7 +36,7 @@ Please see the wiki <a href="{{ site.wiki_url }}/Release-Schedule">GeoTools and 
 <section>
 <p>
 The future direction of GeoServer is primarily shaped by the constant flow of code contributions and funding directed towards the implementation of new features.
-In case you are wondering about a new feature or improvement we have a <a href="{{ site.wiki_url }}/Successfully-requesting-and-integrating-fixes,-improvements-and-new-features-in-GeoServer" >wiki page describing the process to discuss and implement it</a>.
+In case you are wondering about a new feature or improvement we have a <a href="{{ site.wiki_url }}/Successfully-requesting-and-integrating-new-features-and-improvements-in-GeoServer" >wiki page describing the process to discuss and implement it</a>.
 </p>
 </section>
 


### PR DESCRIPTION
The link on the roadmap page is broken:

- https://github.com/geoserver/geoserver/wiki/Successfully-requesting-and-integrating-fixes,-improvements-and-new-features-in-GeoServer

Checking the wiki we have two pages with the same content:

- https://github.com/geoserver/geoserver/wiki/Successfully-requesting-and-integrating-fixes,-improvements-and-new-features-in-GeoServer,-GeoTools-and-GeoWebCache 
- https://github.com/geoserver/geoserver/wiki/Successfully-requesting-and-integrating-new-features-and-improvements-in-GeoServer

