### PR TITLE
CVE disclosure and release anouncements inconsistent

### DIFF
--- a/_posts/2024-02-18-geoserver-2-23-5-released.md
+++ b/_posts/2024-02-18-geoserver-2-23-5-released.md
@@ -24,7 +24,7 @@ with downloads
 This is the last planned maintenance release of GeoServer 2.23.x, providing existing installations with minor updates and bug fixes.
 Sites using the 2.23.x series are encouraged to upgrade to GeoServer 2.24.x, or eventually wait next month, for the 2.25.0 release, and upgrade their installation, with the help of the [upgrade guide](https://docs.geoserver.org/main/en/user/installation/upgrade.html#notes-on-upgrading-specific-versions).
 
-GeoServer 2.23.5 is made in conjunction with GeoTools 29.5, and GeoWebCache 1.23.4. 
+GeoServer 2.23.5 is made in conjunction with GeoTools 29.5, and GeoWebCache 1.23.4.
 
 Thanks to Andrea Aime (GeoSolutions) for making this release. 
 
@@ -33,6 +33,8 @@ Thanks to Andrea Aime (GeoSolutions) for making this release.
 This release addresses security vulnerabilities and is considered an essential upgrade for production systems.
 
 - [CVE-2024-23634](https://github.com/geoserver/geoserver/security/advisories/GHSA-75m5-hh4r-q9gx) Arbitrary file renaming vulnerability in REST Coverage/Data Store API (Moderate)
+
+* [CVE-2024-24749](https://github.com/geoserver/geoserver/security/advisories/GHSA-jhqx-5v5g-mpf3) Classpath resource disclosure in GWC Web Resource API on Windows / Tomcat (Moderate)
 
 See project [security policy](https://github.com/geoserver/geoserver/blob/main/SECURITY.md) for more information on how security vulnerabilities are managed.
 

--- a/_posts/2024-04-18-geoserver-2-24-3-released.md
+++ b/_posts/2024-04-18-geoserver-2-24-3-released.md
@@ -33,6 +33,8 @@ Thanks to Andrea Aime (GeoSolutions) for making this release.
 
   [geoserver-2.24.3-patches.zip](https://sourceforge.net/projects/geoserver/files/GeoServer/2.24.3/geoserver-2.24.3-patches.zip/download) (replacing `gt-app-schema`, `gt-complex` and `gt-xsd-core` jars) has been provided by Andrea (GeoSolutions)
 
+* [CVE-2024-24749](https://github.com/geoserver/geoserver/security/advisories/GHSA-jhqx-5v5g-mpf3) Classpath resource disclosure in GWC Web Resource API on Windows / Tomcat (Moderate)
+
 See project [security policy](https://github.com/geoserver/geoserver/blob/main/SECURITY.md) for more information on how security vulnerabilities are managed. 
 
 

--- a/_posts/2024-05-23-geoserver-2-25-1-released.md
+++ b/_posts/2024-05-23-geoserver-2-25-1-released.md
@@ -37,6 +37,8 @@ This release addresses security vulnerabilities and is considered an essential u
 
   [geoserver-2.25.1-patches.zip](https://sourceforge.net/projects/geoserver/files/GeoServer/2.25.1/geoserver-2.25.1-patches.zip/download) (replacing `gt-app-schema`, `gt-complex` and `gt-xsd-core` jars) has been provided by Andrea (GeoSolutions)
 
+* [CVE-2024-34696](https://github.com/geoserver/geoserver/security/advisories/GHSA-j59v-vgcr-hxvf) GeoServer About Status lists sensitive Environmental Variables (Moderate)
+
 See project [security policy](https://github.com/geoserver/geoserver/blob/main/SECURITY.md) for more information on how security vulnerabilities are managed.
 
 ## Raster Attribute Table Extension

--- a/_posts/2024-06-18-geoserver-2-24-4-released.md
+++ b/_posts/2024-06-18-geoserver-2-24-4-released.md
@@ -32,7 +32,6 @@ Thanks to Peter Smythe (AfriGIS) for making this release.
 This release addresses security vulnerabilities and is considered an essential upgrade for production systems.
 
 * [CVE-2024-36401](https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv) Remote Code Execution (RCE) vulnerability in evaluating property name expressions (Critical)
-* [CVE-2024-24749](https://github.com/geoserver/geoserver/security/advisories/GHSA-jhqx-5v5g-mpf3) Classpath resource disclosure in GWC Web Resource API on Windows / Tomcat (Moderate)
 * [CVE-2024-34696](https://github.com/geoserver/geoserver/security/advisories/GHSA-j59v-vgcr-hxvf) GeoServer About Status lists sensitive Environmental Variables (Moderate)
 
 The use of the CVE system allows the GeoServer team to reach a wider audience than blog posts.  See project [security policy](https://github.com/geoserver/geoserver/blob/main/SECURITY.md) for more information on how security vulnerabilities are managed.

--- a/_posts/2024-06-18-geoserver-2-25-2-released.md
+++ b/_posts/2024-06-18-geoserver-2-25-2-released.md
@@ -32,7 +32,6 @@ This release addresses security vulnerabilities and is considered an essential u
 
 * [CVE-2024-36401](https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv) Remote Code Execution (RCE) vulnerability in evaluating property name expressions (Critical)
 * [CVE-2024-24749](https://github.com/geoserver/geoserver/security/advisories/GHSA-jhqx-5v5g-mpf3) Classpath resource disclosure in GWC Web Resource API on Windows / Tomcat (Moderate)
-* [CVE-2024-34696](https://github.com/geoserver/geoserver/security/advisories/GHSA-j59v-vgcr-hxvf) GeoServer About Status lists sensitive Environmental Variables (Moderate)
 * CVE-2024-35230 Moderate
 
 The use of the CVE system allows the GeoServer team to reach a wider audience than blog posts. See the project [security policy](https://github.com/geoserver/geoserver/blob/main/SECURITY.md) for more information on how security vulnerabilities are managed.


### PR DESCRIPTION
Seems some of the CVE and release announcements were inconsistent, this PR fixes.

aside: We now use placeholder CVEs to avoid this kind of inconsistency.