### PR TITLE
GeoServer 2.22.6 release with recent GeoTools 28.6 jars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ _site
 .jekyll-cache
 Gemfile.lock
 *.bak
+venv

--- a/_posts/2023-08-30-geoserver-2-22-5-released.md
+++ b/_posts/2023-08-30-geoserver-2-22-5-released.md
@@ -22,7 +22,7 @@ with downloads (
 [extensions](https://sourceforge.net/projects/geoserver/files/GeoServer/2.22.5/extensions/).
 
 This is a maintenance release of GeoServer providing existing installations with minor updates and bug fixes.
-GeoServer 2.22.5 is made in conjunction with GeoTools 28.5, and GeoWebCache 1.22.5. 
+GeoServer 2.22.5 is made in conjunction with GeoTools 28.5. 
 
 Thanks to Peter Smythe (AfriGIS) for making this release.
 

--- a/_posts/2024-06-13-geoserver-2-23-6-released.md
+++ b/_posts/2024-06-13-geoserver-2-23-6-released.md
@@ -34,6 +34,8 @@ Thanks to Jody Garnett (GeoCat) for making this release on behalf of GeoCat cust
 This release addresses security vulnerabilities and is considered an essential update for production systems.
 
 * [CVE-2024-36401](https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv) Remote Code Execution (RCE) vulnerability in evaluating property name expressions (Critical)
+  
+  For more information see the following [statement]({% post_url 2024-09-12-cve-2024-36401 %}).
 
 See project [security policy](https://github.com/geoserver/geoserver/blob/main/SECURITY.md) for more information on how security vulnerabilities are managed.
 

--- a/_posts/2024-06-18-geoserver-2-24-4-released.md
+++ b/_posts/2024-06-18-geoserver-2-24-4-released.md
@@ -32,6 +32,9 @@ Thanks to Peter Smythe (AfriGIS) for making this release.
 This release addresses security vulnerabilities and is considered an essential upgrade for production systems.
 
 * [CVE-2024-36401](https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv) Remote Code Execution (RCE) vulnerability in evaluating property name expressions (Critical)
+  
+  For more information see the following [statement]({% post_url 2024-09-12-cve-2024-36401 %}).
+
 * [CVE-2024-34696](https://github.com/geoserver/geoserver/security/advisories/GHSA-j59v-vgcr-hxvf) GeoServer About Status lists sensitive Environmental Variables (Moderate)
 
 The use of the CVE system allows the GeoServer team to reach a wider audience than blog posts.  See project [security policy](https://github.com/geoserver/geoserver/blob/main/SECURITY.md) for more information on how security vulnerabilities are managed.

--- a/_posts/2024-06-18-geoserver-2-25-2-released.md
+++ b/_posts/2024-06-18-geoserver-2-25-2-released.md
@@ -31,8 +31,11 @@ Thanks to Jody Garnett (GeoCat) for making this release on behalf of GeoCat cust
 This release addresses security vulnerabilities and is considered an essential upgrade for production systems.
 
 * [CVE-2024-36401](https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv) Remote Code Execution (RCE) vulnerability in evaluating property name expressions (Critical)
-* [CVE-2024-24749](https://github.com/geoserver/geoserver/security/advisories/GHSA-jhqx-5v5g-mpf3) Classpath resource disclosure in GWC Web Resource API on Windows / Tomcat (Moderate)
-* CVE-2024-35230 Moderate
+
+  For more information see the following [statement]({% post_url 2024-09-12-cve-2024-36401 %}).
+
+* [CVE-2024-24749](https://github.com/geoserver/geoserver/security/advisories/GHSA-jhqx-5v5g-mpf3) Classpath resource disclosure in GWC Web Resource API on Windows / Tomcat (Moderate 5.9)
+* [CVE-2024-35230](https://github.com/geoserver/geoserver/security/advisories/GHSA-6pfc-w86r-54q6) Welcome and About GeoServer pages communicate version and revision information (Moderate 5.3)
 
 The use of the CVE system allows the GeoServer team to reach a wider audience than blog posts. See the project [security policy](https://github.com/geoserver/geoserver/blob/main/SECURITY.md) for more information on how security vulnerabilities are managed.
 

--- a/_posts/2024-09-12-cve-2024-36401.md
+++ b/_posts/2024-09-12-cve-2024-36401.md
@@ -15,6 +15,7 @@ For more information:
 
 * [GeoServer 2.25.2 Release]({% post_url 2024-06-18-geoserver-2-25-2-released %}) (Jun 18, 2024)
 * [GeoServer 2.24.4 Release]({% post_url 2024-06-18-geoserver-2-24-4-released %}) (Jun 18, 2024)
+* [GeoServer 2.22.6 Release]({% post_url 2025-03-17-geoserver-2-22-6-released %}) (Mar 17, 2025)
 * [CVE-2024-36401](https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv) (July 1, 2024)
 * [CISA Warns of Actively Exploited RCE Flaw in GeoServer GeoTools Software](https://thehackernews.com/2024/07/cisa-warns-of-actively-exploited-rce.html) (The Hacker News, July 18, 2024)
 * [GeoServer Vulnerability Targeted by Hackers to Deliver Backdoors and Botnet Malware](https://thehackernews.com/2024/09/geoserver-vulnerability-targeted-by.html) (The Hacker News, September 6, 2024)
@@ -53,7 +54,7 @@ Patch provided with [CVE-2024-36401](https://github.com/geoserver/geoserver/secu
 * GeoServer 2.19.2 (GeoSolutions)
 * GeoServer 2.18.0 (GeoSolutions)
 
-Free software is a participation sport - to create a patch for a prior release volunteer with [community development](https://geoserver.org/devel/).
+Free software is a participation sport - to create a patch for a prior release volunteer with [community development](/devel/).
 
 ## Q: How often should I upgrade GeoServer?
 

--- a/_posts/2025-03-17-geoserver-2-22-6-released.md
+++ b/_posts/2025-03-17-geoserver-2-22-6-released.md
@@ -1,0 +1,95 @@
+---
+author: Jody Garnett
+date: 2025-03-17
+layout: post
+title: GeoServer 2.22.6 Release
+categories:
+- Announcements
+- Vulnerability
+tags:
+- Release
+release: release_222
+version: 2.22.6
+jira_version: 16898
+--- 
+
+GeoServer [2.22.6](/release/2.22.6/) release is now available
+with downloads
+([bin](https://sourceforge.net/projects/geoserver/files/GeoServer/2.22.6/geoserver-2.22.6-bin.zip/download),
+[war](https://sourceforge.net/projects/geoserver/files/GeoServer/2.22.6/geoserver-2.22.6-war.zip/download),
+[windows](https://sourceforge.net/projects/geoserver/files/GeoServer/2.22.6/GeoServer-2.22.6-winsetup.exe/download)), along with 
+[docs](https://sourceforge.net/projects/geoserver/files/GeoServer/2.22.6/geoserver-2.22.6-htmldoc.zip/download) and
+[extensions](https://sourceforge.net/projects/geoserver/files/GeoServer/2.22.6/extensions/).
+
+This series has previously reached end-of-life, with this release issued to address a security vulnerability. Please apply this update as a mitigation measure only, and plan to upgrade to a stable or maintenance release of GeoServer.
+GeoServer 2.22.6 is made in conjunction with GeoTools 28.6. 
+
+Thanks to Jody Garnett for making this release. 
+
+## Security Considerations
+
+This release addresses security vulnerabilities for those operating in a Java 8 environment:
+
+* [CVE-2024-36401](https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv) Remote Code Execution (RCE) vulnerability in evaluating property name expressions (Critical)
+  
+  For more information see the following [statement]({% post_url 2024-09-12-cve-2024-36401 %}).
+
+See project [security policy](https://github.com/geoserver/geoserver/blob/main/SECURITY.md) for more information on how security vulnerabilities are managed. 
+
+## Java 8 End-of-life
+
+This GeoServer 2.22.6 is archived and has reached end-of-life. This release uses recent GeoTools 28.6 Java 8 artifacts addressing [CVE-2024-36404](https://github.com/geotools/geotools/security/advisories/GHSA-w3pj-wh35-fq8w).
+
+All future releases will require a minimum of Java 11.
+
+## Release notes
+
+Improvement:
+
+* [GEOS-11102](https://osgeo-org.atlassian.net/browse/GEOS-11102) Allow configuration of the CSV date format
+* [GEOS-11116](https://osgeo-org.atlassian.net/browse/GEOS-11116) GetMap/GetFeatureInfo with groups and view params can with mismatched layers/params
+* [GEOS-11155](https://osgeo-org.atlassian.net/browse/GEOS-11155) Add the X-Content-Type-Options header
+* [GEOS-11246](https://osgeo-org.atlassian.net/browse/GEOS-11246) Schemaless plugin performance for WFS
+
+Bug:
+
+* [GEOS-11138](https://osgeo-org.atlassian.net/browse/GEOS-11138) Jetty unable to start  cvc-elt.1.a / org.xml.sax.SAXParseException
+
+Task:
+
+* [GEOS-11318](https://osgeo-org.atlassian.net/browse/GEOS-11318) Upgrade postgresql from 42.6.0 to 42.7.2
+
+For the complete list see [2.22.6](https://github.com/geoserver/geoserver/releases/tag/2.22.6) release notes. 
+
+## Community Updates
+
+Community module development:
+
+* [GEOS-11412](https://osgeo-org.atlassian.net/browse/GEOS-11412) Remove reference to JDOM from JMS Cluster (as JDOM is no longer in use)
+
+Community modules are shared as source code to encourage collaboration. If a topic being explored is of interest to you, please contact the module developer to offer assistance. 
+
+# About GeoServer 2.22 Series
+
+Additional information on GeoServer 2.22 series:
+
+* [GeoServer 2.22 User Manual](https://docs.geoserver.org/2.22.x/en/user/)
+* [Update Instructions](https://docs.geoserver.org/latest/en/user/installation/upgrade.html)
+* [Metadata extension](https://docs.geoserver.org/latest/en/user/extensions/metadata/index.html)
+* [CSW ISO Metadata extension](https://docs.geoserver.org/latest/en/user/extensions/csw-iso/index.html)
+* [State of GeoServer](https://docs.google.com/presentation/d/1mnOFSvYb8npVudvUR5MSjSTFHc6ZQ_bStafZrBV7LZ8/edit?usp=sharing) (FOSS4G Presentation)
+* [GeoServer Beginner Workshop](https://docs.google.com/presentation/d/1fbPLN-1Cs95WK-IxDG1PxCEKyHwFbNBGNkkomxmLr0Y/edit?usp=sharing) (FOSS4G Workshop)
+* [Welcome page](https://docs.geoserver.org/latest/en/user/webadmin/welcome.html) (User Guide)
+
+Release notes:
+( [2.22.6](https://github.com/geoserver/geoserver/releases/tag/2.22.6)
+| [2.22.5](https://github.com/geoserver/geoserver/releases/tag/2.22.5)
+| [2.22.4](https://github.com/geoserver/geoserver/releases/tag/2.22.4)
+| [2.22.3](https://github.com/geoserver/geoserver/releases/tag/2.22.3)
+| [2.22.2](https://github.com/geoserver/geoserver/releases/tag/2.22.2)
+| [2.22.1](https://github.com/geoserver/geoserver/releases/tag/2.22.1)
+| [2.22.0](https://github.com/geoserver/geoserver/releases/tag/2.22.0)
+| [2.22-RC](https://github.com/geoserver/geoserver/releases/tag/2.22-RC)
+| [2.22-M0](https://github.com/geoserver/geoserver/releases/tag/2.22-M0)
+) 
+

--- a/bin/README.md
+++ b/bin/README.md
@@ -1,5 +1,12 @@
 # Announcement Generation
 
+The announcement script is written in python:
+```
+virtualenv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
 Write a blog post announcing the new release:
 ```
 cd bin


### PR DESCRIPTION
With the recent GeoTools 28.6 jars made for geonetwork I had the request to make a Java 8 release of GeoServer.

The resulting release is still well past end-of-life with known security vulnerabilities.

This blog post is scheduled for Monday, when [CVE-2024-36401](https://github.com/geoserver/geoserver/security/advisories/GHSA-6jj6-gm7p-fcvv) record can be updated for automated tools. 


See also https://github.com/geoserver/geoserver/releases/tag/2.22.6