### PR TITLE
Remove the importer-bdb-plugin from the release templates

### DIFF
--- a/_layouts/release_27.html
+++ b/_layouts/release_27.html
@@ -253,7 +253,7 @@
                   <li><a dl="geosearch-plugin">GeoSearch</a></li>
                   <li><a dl="cas-plugin">CAS</a></li>
                   <li>Monitor (<a dl="monitor-plugin">Core</a>, <a dl="monitor-hibernate-plugin">Hibernate</a>)</li>
-                  <li>Importer (<a dl="importer-plugin">Core</a>, <a dl="importer-bdb-plugin">BDB Backend</a>)</li>
+                  <li>Importer (<a dl="importer-plugin">Core</a>)</li>
                   <li><a dl="inspire-plugin">INSPIRE</a></li>
                   <li><a dl="printing-plugin">Printing</a></li>
                 </ul>

--- a/_layouts/release_28.html
+++ b/_layouts/release_28.html
@@ -253,7 +253,7 @@
                   <li><a dl="geosearch-plugin">GeoSearch</a></li>
                   <li><a dl="cas-plugin">CAS</a></li>
                   <li>Monitor (<a dl="monitor-plugin">Core</a>, <a dl="monitor-hibernate-plugin">Hibernate</a>)</li>
-                  <li>Importer (<a dl="importer-plugin">Core</a>, <a dl="importer-bdb-plugin">BDB Backend</a>)</li>
+                  <li>Importer (<a dl="importer-plugin">Core</a>)</li>
                   <li><a dl="inspire-plugin">INSPIRE</a></li>
                   <li><a dl="printing-plugin">Printing</a></li>
                 </ul>

--- a/_layouts/release_29.html
+++ b/_layouts/release_29.html
@@ -255,7 +255,7 @@
                   <li><a dl="css-plugin">CSS Styling</a></li>
                   <li><a dl="cas-plugin">CAS</a></li>
                   <li>Monitor (<a dl="monitor-plugin">Core</a>, <a dl="monitor-hibernate-plugin">Hibernate</a>)</li>
-                  <li>Importer (<a dl="importer-plugin">Core</a>, <a dl="importer-bdb-plugin">BDB Backend</a>)</li>
+                  <li>Importer (<a dl="importer-plugin">Core</a>)</li>
                   <li><a dl="inspire-plugin">INSPIRE</a></li>
                   <li><a dl="printing-plugin">Printing</a></li>
                 </ul>


### PR DESCRIPTION
AFAIK the "importer-bdb-plugin" no longer exists.
see also: https://discourse.osgeo.org/t/importer-bdb-backend-plugin-not-found/149873