### PR TITLE
List OIDC as a supported extension on the 3.0 release page

### DIFF
--- a/_layouts/release_30.html
+++ b/_layouts/release_30.html
@@ -238,6 +238,7 @@
                 <ul>
                   <li><a dl="authkey-plugin">Key authentication</a></li>
                   <li><a dl="cas-plugin">CAS</a></li>
+                  <li><a dl="sec-oidc-plugin">OIDC</a></li>
                   <!--
                   <li><a dl="geofence-plugin">GeoFence Client</a>
                   <li>GeoFence Server (<a dl="geofence-server-postgres-plugin">Postgres</a>)</li>
@@ -289,31 +290,6 @@
                 <h4>Web Services</h4>
                 <ul>
                   <li><a dl="sldservice-plugin">SLDService</a></li>
-                </ul>
-              </div>
-            </div>
-          </section>
-          <section>
-            <h2>Community</h2>
-            <div class="row">
-              <div class="col-sm-6">
-                <div class="row">
-                  <div class="col-xs-2">
-                    <img src="/img/dl-download.png" class="img-responsive"></img>
-                  </div>
-                  <div class="col-xs-10">
-                    <p>
-                      Experimental community modules.
-                    </p>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div class="row">
-              <div class="col-sm-6">
-                <h4>Pending</h4>
-                <ul>
-                  <li><a href="{{site.sf_url}}/files/GeoServer/{{page.version}}/community/geoserver-{{page.version}}-sec-oidc-plugin.zip">OIDC</a></li>
                 </ul>
               </div>
             </div>


### PR DESCRIPTION
OIDC (`sec-oidc`) is being promoted from a community module to a supported security extension in GeoServer 3.0 (GSIP-239 / GEOS-12132), companion to geoserver/geoserver#9578.

This updates the 3.0 release page so OIDC appears under **Extensions › Security** (next to CAS) instead of **Community**:

- Adds `<li><a dl="sec-oidc-plugin">OIDC</a></li>` under Extensions › Security — the layout's JS resolves a `dl="…-plugin"` value to the `extensions/` download path automatically, so the plugin downloads from `extensions/` rather than `community/`.
- Removes OIDC from the Community section; since it was the only entry there, the now-empty Community section is dropped.
