### PR TITLE
GeoServer 3.0.0 Release

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,10 +16,10 @@ url:         https://geoserver.org
 ##
 
 # latest nightly build
-main_series:      3.0.x
+main_series:      3.1.x
 
 # the next jira release for the release/main nightly build
-main_nightly:     17404
+main_nightly:     18000
 
 ##
 ## DEVELOPMENT BRANCH
@@ -31,27 +31,27 @@ main_nightly:     17404
 dev_branch:       main
 
 # the next jira release for the release/<dev_branch> nightly build
-dev_nightly:      17471
+dev_nightly:      18000
 
 ##
 ## STABLE BRANCH
 ##
 
 # stable          determine release/stable page, stable_version and stale_jira
-stable_branch:    2.28.x
+stable_branch:    3.0.x
 
 # the next jira release for the release/<stable_branch>
-stable_nightly:   18034
+stable_nightly:   18069
 
 ##
 ## MAINTENANCE BRANCH
 #
 
 # maintenance     determine release/maintenance page, maintain_version and maintain_jira
-maintain_branch:  2.27.x
+maintain_branch:  2.28.x
 
 # the next jira release for the release/<maintain_branch> nightly build
-maintain_nightly: 17835
+maintain_nightly: 18034
 
 
 timezone:    UTC

--- a/_layouts/nightly_30.html
+++ b/_layouts/nightly_30.html
@@ -178,6 +178,7 @@
                   <li>GeoFence Server (<a dl="geofence-server-postgres-plugin">Postgres</a>)</li>
                   <li><a dl="geofence-plugin">GeoFence WPS</a>
                   -->
+                  <li><a dl="sec-oidc-plugin">OIDC</a></li>
                 </ul>
               </div>
               <div class="col-sm-6">
@@ -249,7 +250,6 @@
               <div class="col-sm-6">
                 <h4>Pending</h4>
                 <ul>
-                  <li><a href="{{site.nightly_url}}/{{page.branch}}/community-latest/geoserver-{{page.series}}-SNAPSHOT-sec-oidc-plugin.zip">OIDC</a></li>
                   <li>OpenSearch (<a href="{{site.nightly_url}}/{{page.branch}}/community-latest/geoserver-{{page.series}}-SNAPSHOT-oseo-plugin.zip">EO</a>)</li>
                 </ul>
               </div>

--- a/_layouts/nightly_31.html
+++ b/_layouts/nightly_31.html
@@ -142,7 +142,6 @@
                 <ul>
                   <li><a dl="app-schema-plugin">App Schema</a></li>
                   <li><a dl="db2-plugin">DB2</a></li>
-                  <li><a dl="h2-plugin">H2</a></li>
                   <li><a dl="mongodb-plugin">MongoDB</a></li>
                   <li><a dl="mysql-plugin">MySQL</a></li>
                   <li><a dl="oracle-plugin">Oracle</a></li>
@@ -176,7 +175,7 @@
                   <li><a dl="cas-plugin">CAS</a></li>
                   <!--
                   <li><a dl="geofence-plugin">GeoFence Client</a>
-                  <li>GeoFence Server (<a dl="geofence-server-h2-plugin">H2</a>, <a dl="geofence-server-postgres-plugin">Postgres</a>)</li>
+                  <li>GeoFence Server (<a dl="geofence-server-postgres-plugin">Postgres</a>)</li>
                   <li><a dl="geofence-plugin">GeoFence WPS</a>
                   -->
                   <li><a dl="sec-oidc-plugin">OIDC</a></li>
@@ -185,12 +184,14 @@
               <div class="col-sm-6">
                 <h4>Coverage Formats</h4>
                 <ul>
+                  <li><a dl="arcgrid-plugin">ArcGrid</a></li>
                   <li><a dl="gdal-plugin">GDAL</a></li>
                   <li><a dl="grib-plugin">GRIB</a></li>
                   <li><a dl="pyramid-plugin">Image Pyramid</a></li>
                   <li><a dl="jp2k-plugin">JPEG2K</a></li>
                   <li><a dl="netcdf-plugin">NetCDF</a></li>
                   <li><a dl="rat-plugin">Raster Attribute Table</a></li>
+                  <li><a dl="image-plugin">WorldImage</a></li>
                 </ul>
                 <h4>Output Formats</h4>
                 <ul>
@@ -211,10 +212,8 @@
                 </ul>
                 <h4>OGC Services</h4>
                 <ul>
-                  <li><a dl="arcgrid-plugin">ArcGrid</a></li>
                   <li><a dl="csw-plugin">CSW</a></li>
                   <li><a dl="csw-iso-plugin">CSW ISO Metadata Profile</a></li>
-                  <li><a dl="image-plugin">WorldImage</a></li>
                   <li><a dl="wcs1_0-plugin">WCS 1.0</a></li>
                   <li><a dl="wcs1_1-plugin">WCS 1.1</a></li>
                   <li><a dl="wcs2_0-eo-plugin">WCS 2.0 EO</a></li>
@@ -239,7 +238,7 @@
                     <img src="/img/dl-download.png" class="img-responsive"></img>
                   </div>
                   <div class="col-xs-10">
-                    <a href="{{site.nightly_url}}/{{page.branch}}/community-latest">Community Modules</a>
+                    <a href="{{site.nightly_url}}/{{page.branch}}/community-latest">Community Modules</a>                  
                     <p>
                       Experimental community modules.
                     </p>
@@ -251,7 +250,7 @@
               <div class="col-sm-6">
                 <h4>Pending</h4>
                 <ul>
-                  <li>OpenSearch (<a dl="oseo-plugin">EO</a>)</li>
+                  <li>OpenSearch (<a href="{{site.nightly_url}}/{{page.branch}}/community-latest/geoserver-{{page.series}}-SNAPSHOT-oseo-plugin.zip">EO</a>)</li>
                 </ul>
               </div>
             </div>

--- a/_layouts/release_30.html
+++ b/_layouts/release_30.html
@@ -238,12 +238,12 @@
                 <ul>
                   <li><a dl="authkey-plugin">Key authentication</a></li>
                   <li><a dl="cas-plugin">CAS</a></li>
-                  <li><a dl="sec-oidc-plugin">OIDC</a></li>
                   <!--
                   <li><a dl="geofence-plugin">GeoFence Client</a>
                   <li>GeoFence Server (<a dl="geofence-server-postgres-plugin">Postgres</a>)</li>
                   <li><a dl="geofence-plugin">GeoFence WPS</a>
                   -->
+                  <li><a dl="sec-oidc-plugin">OIDC</a></li>
                 </ul>
               </div>
               <div class="col-sm-6">
@@ -290,6 +290,32 @@
                 <h4>Web Services</h4>
                 <ul>
                   <li><a dl="sldservice-plugin">SLDService</a></li>
+                </ul>
+              </div>
+            </div>
+          </section>
+          <section>
+            <h2>Community</h2>
+            <div class="row">
+              <div class="col-sm-6">
+                <div class="row">
+                  <div class="col-xs-2">
+                    <img src="/img/dl-download.png" class="img-responsive"></img>
+                  </div>
+                  <div class="col-xs-10">
+                    Community Modules
+                    <p>
+                      Experimental community modules.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="row">
+              <div class="col-sm-6">
+                <h4>Pending</h4>
+                <ul>
+                  <li>OpenSearch (<a dl="oseo-plugin">EO</a>)</li>
                 </ul>
               </div>
             </div>

--- a/_plugins/release.rb
+++ b/_plugins/release.rb
@@ -76,7 +76,7 @@ module ReleasePlugin
       site.pages << NightlyPage.new(
         site, 
         'main',
-        site.config['main_series'][0..-3],
+        site.config['main_series'].rpartition(".")[0..1].join,
         'latest',
         site.config['main_nightly']
       )

--- a/_posts/2025-04-03-geoserver-2-27-0-released.md
+++ b/_posts/2025-04-03-geoserver-2-27-0-released.md
@@ -73,6 +73,9 @@ Finally, thanks to Andrea, Peter and Gabriel for reviewing feedback and addressi
 
 This release addresses several security vulnerabilities, and is a recommended upgrade for production systems.
 
+
+* [GEOS-12043](https://osgeo-org.atlassian.net/browse/GEOS-12043) CVE-2025-27511 JNDI Vulnerability in DB2 Store Connection
+* [GEOS-11777](https://osgeo-org.atlassian.net/browse/GEOS-11777) CVE-2024-45747 Server-Side Template Injection (SSTI) vulnerability in processing FreeMarker templates
 * [CVE-2025-30145](https://github.com/geoserver/geoserver/security/advisories/GHSA-gr67-pwcv-76gf) Denial-of-service (DoS) Vulnerability in Jiffle process (High)
 * [CVE-2025-27505](https://github.com/geoserver/geoserver/security/advisories/GHSA-h86g-x8mm-78m5) Missing Authorization on REST API Index (Moderate)
 * [CVE-2024-29198](https://github.com/geoserver/geoserver/security/advisories/GHSA-5gw5-jccf-6hxw) Unauthenticated SSRF via TestWfsPost (Moderate)

--- a/_posts/2025-05-13-geoserver-2-26-3-released.md
+++ b/_posts/2025-05-13-geoserver-2-26-3-released.md
@@ -30,6 +30,7 @@ Thanks to Jody Garnett and Andrea Aime (GeoSolutions) for making this release.
 
 This release addresses security vulnerabilities and is considered an critical update for existing installations.
 
+* [GEOS-12043](https://osgeo-org.atlassian.net/browse/GEOS-12043) CVE-2025-27511 JNDI Vulnerability in DB2 Store Connection
 * [CVE-2025-30220](https://github.com/geoserver/geoserver/security/advisories/GHSA-jj54-8f66-c5pc) XML External Entity (XXE) Processing Vulnerability in GeoServer WFS Service (High)
 
 * [CVE-2025-30145](https://github.com/geoserver/geoserver/security/advisories/GHSA-gr67-pwcv-76gf) Denial-of-service (DoS) Vulnerability in Jiffle process (High)

--- a/_posts/2025-09-01-geoserver-2-26-4-released.md
+++ b/_posts/2025-09-01-geoserver-2-26-4-released.md
@@ -30,7 +30,8 @@ Thanks to Peter Smythe (AfriGIS) for making this release, and to Jody for testin
 
 This release addresses security vulnerabilities and is considered an important update for existing installations.
 
-<!-- update cve list details when disclosed --> 
+* [GEOS-11920](https://osgeo-org.atlassian.net/browse/GEOS-11920) CVE-2025-58175 Server-Side Request Forgery (SSRF) Vulnerability in XML entity resolution
+* [GEOS-11918](https://osgeo-org.atlassian.net/browse/GEOS-11918) CVE-2025-52465 Arbitrary file write vulnerability in Master Password Dump Page
 
 The use of the CVE system allows the GeoServer team to reach a wider audience than blog posts. See project [security policy](https://github.com/geoserver/geoserver/blob/main/SECURITY.md) for more information on how security vulnerabilities are managed.
 

--- a/_posts/2025-10-14-geoserver-2-28-0-released.md
+++ b/_posts/2025-10-14-geoserver-2-28-0-released.md
@@ -31,6 +31,9 @@ and testing of the 2.28-M0 milestone release.
 
 This release addresses security vulnerabilities and is considered an important upgrade for production systems.
 
+* [GEOS-11777](https://osgeo-org.atlassian.net/browse/GEOS-11777) CVE-2024-45747 Server-Side Template Injection (SSTI) vulnerability in processing FreeMarker templates
+* [GEOS-11920](https://osgeo-org.atlassian.net/browse/GEOS-11920) CVE-2025-58175 Server-Side Request Forgery (SSRF) Vulnerability in XML entity resolution
+* [GEOS-11918](https://osgeo-org.atlassian.net/browse/GEOS-11918) CVE-2025-52465 Arbitrary file write vulnerability in Master Password Dump Page
 * [GEOS-11921](https://osgeo-org.atlassian.net/browse/GEOS-11921) - [CVE-2025-21621](https://github.com/geoserver/geoserver/security/advisories/GHSA-w66h-j855-qr72) - Reflected Cross-Site Scripting (XSS) vulnerability in WMS GetFeatureInfo HTML format (Moderate)
 * [GEOS-11922](https://osgeo-org.atlassian.net/browse/GEOS-11922) - [CVE-2025-58360](https://github.com/geoserver/geoserver/security/advisories/GHSA-fjf5-xgmq-5525) - Unauthenticated XXE via WMS GetMap (High)
 

--- a/_posts/2025-10-21-geoserver-2-27-3-released.md
+++ b/_posts/2025-10-21-geoserver-2-27-3-released.md
@@ -30,6 +30,9 @@ Thanks to Jody Garnett (GeoCat) for making this release.
 
 This release addresses security vulnerabilities and is an important upgrade for production systems.
 
+* [GEOS-11920](https://osgeo-org.atlassian.net/browse/GEOS-11920) CVE-2025-58175 Server-Side Request Forgery (SSRF) Vulnerability in XML entity resolution
+* [GEOS-11918](https://osgeo-org.atlassian.net/browse/GEOS-11918) CVE-2025-52465 Arbitrary file write vulnerability in Master Password Dump Page
+  
 See project [security policy](https://github.com/geoserver/geoserver/blob/main/SECURITY.md) for more information on how security vulnerabilities are managed.
 
 ## Upgrade instructions

--- a/_posts/2026-05-25-geoserver-2-28-4-released.md
+++ b/_posts/2026-05-25-geoserver-2-28-4-released.md
@@ -17,7 +17,7 @@ GeoServer [2.28.4](/release/2.28.4/) release is now available
 with downloads
 ([bin](https://sourceforge.net/projects/geoserver/files/GeoServer/2.28.4/geoserver-2.28.4-bin.zip/download),
 [war](https://sourceforge.net/projects/geoserver/files/GeoServer/2.28.4/geoserver-2.28.4-war.zip/download),
-~~[windows](https://sourceforge.net/projects/geoserver/files/GeoServer/2.28.4/GeoServer-2.28.4-winsetup.exe/download)~~), along with 
+[windows](https://sourceforge.net/projects/geoserver/files/GeoServer/2.28.4/GeoServer-2.28.4-winsetup.exe/download)), along with 
 [docs](https://sourceforge.net/projects/geoserver/files/GeoServer/2.28.4/geoserver-2.28.4-htmldoc.zip/download) and
 [extensions](https://sourceforge.net/projects/geoserver/files/GeoServer/2.28.4/extensions/).
 

--- a/_posts/2026-06-11-geoserver-3-0-0-here-crowdfunding.md
+++ b/_posts/2026-06-11-geoserver-3-0-0-here-crowdfunding.md
@@ -1,0 +1,49 @@
+---
+author: Nuno Oliveira
+layout: post
+title: GeoServer 3 is here, from crowdfunding to release
+date: 2026-06-11
+categories:
+- Behind The Scenes
+tags:
+- GeoServer 3
+- Crowdfunding
+- Community
+- Release
+---
+
+[GeoServer 3.0 is now generally available]({% post_url 2026-06-11-geoserver-3-0-0-released %}). This post is not a feature announcement, those have been written, and the release notes cover the details. This is something we get to do less often: closing the loop on a promise. The modernisation work the community funded is finished and shipping, and we want to account for what that funding set out to achieve and what it delivered.
+
+The result is a platform brought back onto a current, supported foundation. The work reached across the wider ecosystem rather than GeoServer alone, and the scope the campaign promised has been covered.
+
+## **The bet the community made**
+
+The case for GeoServer 3 was clear. Spring 5 was reaching the end of security support, and staying on a supported, modern Java platform meant moving to JDK 17\. That upgrade was the trigger for much of what followed, because it could not happen in isolation: it cascaded into Spring 7, Jakarta, modern servlet containers, and updated libraries across the stack, and the ageing image-processing components had to be replaced along the way. None of this is the kind of work that wins a feature vote, yet all of it keeps GeoServer current and dependable for the years ahead. Our goal was to take this foundational work directly, in one coordinated effort across the whole ecosystem, rather than letting it pile up.
+
+Funding it required a structure built on trust. [The financial target was 550,000 €](https://geoserver.org/sponsor/gs3-crowdfunding). Camptocamp, GeoCat, and GeoSolutions each contributed 50,000 €, and the consortium provided coordination, delivery capacity, and co-funding to move the project forward. That left a community funding goal of 400,000 €, pledged by sponsors, community members, and individual donors during a commitment phase, with funds collected only once the target was reached, so the work could begin fully funded rather than at risk of stalling partway. In May 2025 the [campaign passed its goal](https://geoserver.org/behind%20the%20scenes/2025/05/13/gs3-crowdfunding-surpassed.html), and the work began fully funded. GeoServer 3.0 is the moment it pays out.
+
+## **What the funding delivered**
+
+GeoServer 3 set out to modernise the platform from the foundation up, and that is what this release delivers. The work was a coordinated programme rather than a single change, where a handful of major upgrades each set off a chain of smaller, necessary changes across the codebase. The items below are the headline changes that triggered much of the surrounding effort.
+
+**A modern Java foundation.** The GeoServer ecosystem now runs on JDK 17 and Spring 7, the central upgrade that drove the rest of the work and brings GeoServer back onto a current, supported stack. That move cascaded into Jakarta, modern servlet containers, and a wide set of supporting libraries that all had to be carried forward together. The project worked through the dependency tree end to end, so the platform sits on a clean, maintainable base.
+
+**Modern raster processing.** ImageN has replaced the legacy image-processing engine, putting raster processing on a modern foundation that is far easier to maintain going forward.
+
+**Reinforced security.** Security and vulnerability management have been strengthened throughout, putting GeoServer on a stronger footing for the kinds of compliance and assurance its users increasingly need.
+
+**A refreshed administration experience and documentation.** The administration interface has been rebuilt with a new context-driven design, and the documentation has been refreshed and updated alongside it.
+
+Just as importantly, this was never only about GeoServer. The funded work carried across the ecosystem, and 3.0 ships together with GeoTools and GeoWebCache, with the integration work for GeoServer Cloud following on, making GeoServer well suited to cloud-native and containerised deployments. For most deployments the upgrade from 2.28.x is straightforward, with no changes required to the data directory. The migration guide provides the necessary instructions for the rest. The release candidate phase let organisations prove all of this in their own environments, and that feedback shaped the final release.
+
+All of this scope was delivered and is available now in the GeoServer 3.0 release.
+
+## **Thank you**
+
+GeoServer is critical infrastructure for countless organisations, and keeping a platform like that healthy depends on funding the unglamorous foundational work that rarely attracts attention on its own. That a community came together to back this effort, and saw it through to a successful delivery, is a meaningful example of how open source can sustain itself when its users choose to invest in it.
+
+That investment had a lot of people behind it. Thank you to every organisation that pledged, every individual who donated, and everyone who tested, reported, reviewed, and contributed code: this release exists because you decided it should. Thank you also to the consortium teams at Camptocamp, GeoCat, and GeoSolutions, who carried it from a funding target to a shipped release.
+
+GeoServer 3 is the foundation for everything the project does next. It is here because the community built it together.
+
+{% include gs3-sponsors.html %}

--- a/_posts/2026-06-11-geoserver-3-0-0-released.md
+++ b/_posts/2026-06-11-geoserver-3-0-0-released.md
@@ -75,7 +75,7 @@ Please see the [upgrade instructions](https://docs.geoserver.org/latest/en/user/
 
 ### Thanks to the GeoServer 3 Sponsors
 
-GeoServer 3 would not exist without the organizations and individuals who supported the [GeoServer 3 crowdfunding campaign](/sponsor/gs3-crowdfunding). Their sponsorship made this work possible.
+GeoServer 3 would not exist without the organizations and individuals who supported the [GeoServer 3 crowdfunding campaign](/sponsor/gs3-crowdfunding). Their sponsorship made this work possible. We also want to share a [final message to reflect over the campaign, its results, and thank again everyone that participate]({% post_url 2026-06-11-geoserver-3-0-0-here-crowdfunding %}) .
 
 {% include gs3-sponsors.html %}
 

--- a/_posts/2026-06-11-geoserver-3-0-0-released.md
+++ b/_posts/2026-06-11-geoserver-3-0-0-released.md
@@ -47,7 +47,7 @@ We have taken great pains to make the upgrade process seamless from GeoServer 2.
 
 1. Important: We have made **no changes** to the GeoServer Data Directory.
    
-   Download and try GeoServer 3.0-RC today!
+   Download and try GeoServer 3.0.0 today!
 
 2. A few modules have migrated from core to extensions:
 

--- a/_posts/2026-06-11-geoserver-3-0-0-released.md
+++ b/_posts/2026-06-11-geoserver-3-0-0-released.md
@@ -21,7 +21,7 @@ with downloads
 [docs](https://sourceforge.net/projects/geoserver/files/GeoServer/3.0.0/geoserver-3.0.0-htmldoc.zip/download) and
 [extensions](https://sourceforge.net/projects/geoserver/files/GeoServer/3.0.0/extensions/).
 
-This is a stable release of GeoServer recommended for production use.
+This is a stable release of GeoServer 3.0.x series.
 GeoServer 3.0.0 is made in conjunction with GeoTools 35.0, and GeoWebCache 2.0.0. 
 
 Thanks to Jody Garnett (GeoCat), and Peter Smythe (AfriGIS) for making this release. 
@@ -30,11 +30,18 @@ Thanks to Jody Garnett (GeoCat), and Peter Smythe (AfriGIS) for making this rele
 
 This release addresses security vulnerabilities and is an important upgrade for production systems.
 
+* [GEOS-12043](https://osgeo-org.atlassian.net/browse/GEOS-12043) CVE-2025-27511 JNDI Vulnerability in DB2 Store Connection
+* [GEOS-11920](https://osgeo-org.atlassian.net/browse/GEOS-11920) CVE-2025-58175 Server-Side Request Forgery (SSRF) Vulnerability in XML entity resolution
+* [GEOS-11918](https://osgeo-org.atlassian.net/browse/GEOS-11918) CVE-2025-52465 Arbitrary file write vulnerability in Master Password Dump Page
+* [GEOS-11777](https://osgeo-org.atlassian.net/browse/GEOS-11777) CVE-2024-45747 Server-Side Template Injection (SSTI) vulnerability in processing FreeMarker templates
+
+The use of the CVE system allows the GeoServer team to reach a wider audience than blog posts. 
+
 See project [security policy](https://github.com/geoserver/geoserver/blob/main/SECURITY.md) for more information on how security vulnerabilities are managed.
 
 ## Welcome to GeoServer 3
 
-We are overjoyed to share the release of GeoServer 3.0 with our community, this is the final stretch of a long road, a year of development, and a lot of planning and support to make it all happen. Thanks to all the organizations and individuals supporting GeoServer 3.
+We are overjoyed to share the initial release of GeoServer 3 with our community, this is the final stretch of a long road, a year of development, and a lot of planning and support to make it all happen. Thanks to all the organizations and individuals supporting GeoServer 3.
 
 <a href="/img/posts/3.0/welcome-global.png" target="_blank" rel="noopener">
   <img src="/img/posts/3.0/welcome-global.png" alt="GeoServer 3" class="screensnap"
@@ -43,11 +50,9 @@ We are overjoyed to share the release of GeoServer 3.0 with our community, this 
 
 ### Straightforward upgrade
 
-We have taken great pains to make the upgrade process seamless from GeoServer 2.28.x.
+Special care has been taken to ensure a seamless upgrade from GeoServer 2.28.x:
 
 1. Important: We have made **no changes** to the GeoServer Data Directory.
-   
-   Download and try GeoServer 3.0.0 today!
 
 2. A few modules have migrated from core to extensions:
 
@@ -75,7 +80,7 @@ Please see the [upgrade instructions](https://docs.geoserver.org/latest/en/user/
 
 ### Thanks to the GeoServer 3 Sponsors
 
-GeoServer 3 would not exist without the organizations and individuals who supported the [GeoServer 3 crowdfunding campaign](/sponsor/gs3-crowdfunding). Their sponsorship made this work possible. We also want to share a [final message to reflect over the campaign, its results, and thank again everyone that participate]({% post_url 2026-06-11-geoserver-3-0-0-here-crowdfunding %}) .
+GeoServer 3 would not exist without the organizations and individuals who supported the [GeoServer 3 crowdfunding campaign](/sponsor/gs3-crowdfunding). Their sponsorship made this work possible. We also want to share a [final message to reflect over the campaign, its results, and thank again everyone that participate]({% post_url 2026-06-11-geoserver-3-0-0-here-crowdfunding %}).
 
 {% include gs3-sponsors.html %}
 
@@ -152,7 +157,7 @@ Thanks to Stefano Bovio (GeoSolutions) for the welcome improvement.
 
 ## Updated Environment
 
-GeoServer 3 is overjoyed to support Tomcat 11.0.x and Jetty 12.1 application servers after completing our transition to Spring Framework 7 and Jakarta EE Servlet API 6.1.
+GeoServer 3 requires Tomcat 11.0.x and Jetty 12.1 application servers. We are really pleased with this accomplishment after completing our transition to Spring Framework 7 and Jakarta EE Servlet API 6.1.
 
 We have been extensively testing GeoServer 3 with Java 17 and Java 21, maintaining the same Java runtime baseline as GeoServer 2.28.x. Java 25 is subject to automated testing, but we are going to hold off recommending it until the user community has had an opportunity to try it out and report back.
 
@@ -183,11 +188,13 @@ Thanks to Alessio Fabiani and others for this important improvement. Special tha
 
 ## New Documentation
 
-The long-awaited transition to Markdown documentation has finally arrived. Welcome to our new [User Manual](https://docs.geoserver.org/latest/en/user/).  The older GeoServer 2.x documentation is available at [Docs Archive](https://docs-archive.geoserver.org/) or via the version switcher.  Please help out by fixing any remaining [small issues](https://docs.geoserver.org/latest/en/docguide/quickfix/) or log an issue for Peter to address.
+The long-awaited transition to Markdown documentation has finally arrived. Welcome to our new [User Manual](https://docs.geoserver.org/latest/en/user/).  The GeoServer 2.x documentation is available using the version switcher at the top of the page.
 
 <a href="https://docs.geoserver.org/main/en/user/">
   <img src="/img/posts/3.0/user-manual.png" alt="The new user manual" class="screensnap"/>
 </a>
+
+Please help out by fixing any remaining [small issues](https://docs.geoserver.org/latest/en/docguide/quickfix/) or log an issue for Peter to address. The [documentation guide has been updated with Markdown guidance](https://docs.geoserver.org/main/en/docguide/markdown/) complete with visual examples.
 
 Thanks to Peter Smythe (AfriGIS) and Jody Garnett (GeoCat) for working on this activity which ended up being an incredible amount of work.
 

--- a/_posts/2026-06-11-geoserver-3-0-0-released.md
+++ b/_posts/2026-06-11-geoserver-3-0-0-released.md
@@ -1,55 +1,40 @@
 ---
 author: Jody Garnett
-date: 2026-04-20
+date: 2026-06-11
 layout: post
-title: GeoServer 3.0-RC Release
+title: GeoServer 3.0.0 Release
 categories:
 - Announcements
+- Vulnerability
 tags:
 - Release
-- Release Candidate
 release: release_30
-version: 3.0-RC
-jira_version: 17934
+version: 3.0.0
+jira_version: 17404
 --- 
 
-GeoServer [3.0-RC](/release/3.0-RC/) is now available, with downloads for
-( [bin](https://sourceforge.net/projects/geoserver/files/GeoServer/3.0-RC/geoserver-3.0-RC-bin.zip/download), 
-[war](https://sourceforge.net/projects/geoserver/files/GeoServer/3.0-RC/geoserver-3.0-RC-war.zip/download)
-<!-- ,[windows](https://sourceforge.net/projects/geoserver/files/GeoServer/3.0-RC/GeoServer-3.0-RC-winsetup.exe/download)-->), along with 
-[docs](https://sourceforge.net/projects/geoserver/files/GeoServer/3.0-RC/geoserver-3.0-RC-htmldoc.zip/download) and
-[extensions](https://sourceforge.net/projects/geoserver/files/GeoServer/3.0-RC/extensions/).
-We are working with OSGeo for the windows installer download, and will update this post when it is available. Windows users are asked to [test out the bin download](https://docs.geoserver.org/main/en/user/installation/win_binary/) while we wait.
-Release available as [docker image](https://github.com/geoserver/docker) `docker.osgeo.org/geoserver:3.0-RC` .
+GeoServer [3.0.0](/release/3.0.0/) release is now available
+with downloads
+([bin](https://sourceforge.net/projects/geoserver/files/GeoServer/3.0.0/geoserver-3.0.0-bin.zip/download),
+[war](https://sourceforge.net/projects/geoserver/files/GeoServer/3.0.0/geoserver-3.0.0-war.zip/download),
+[windows](https://sourceforge.net/projects/geoserver/files/GeoServer/3.0.0/GeoServer-3.0.0-winsetup.exe/download)), along with 
+[docs](https://sourceforge.net/projects/geoserver/files/GeoServer/3.0.0/geoserver-3.0.0-htmldoc.zip/download) and
+[extensions](https://sourceforge.net/projects/geoserver/files/GeoServer/3.0.0/extensions/).
 
-This is a release candidate intended for public review and feedback.
-GeoServer 3.0-RC is made in conjunction with GeoTools 35-RC, and GeoWebCache 2.0-RC. 
+This is a stable release of GeoServer recommended for production use.
+GeoServer 3.0.0 is made in conjunction with GeoTools 35.0, and GeoWebCache 2.0.0. 
 
-Thanks to Jody Garnett (GeoCat), Andrea Aime (GeoSolutions), and Peter Smythe (AfriGIS) for making this release. 
+Thanks to Jody Garnett (GeoCat), and Peter Smythe (AfriGIS) for making this release. 
 
-### Please Test GeoServer 3.0-RC
+## Security Considerations
 
-We encourage everyone to try GeoServer 3.0-RC in their own environment, especially for [upgrade workflows](https://docs.geoserver.org/latest/en/user/installation/upgrade3/), the new user interface, and deployment on Tomcat 11 and Jetty 12. Real-world testing is the best way to catch regressions and compatibility issues before the final 3.0 release.
+This release addresses security vulnerabilities and is an important upgrade for production systems.
 
-You may also quickly test the [docker image](https://github.com/geoserver/docker) using:
-
-```bash
-docker run -p 8080:8080 docker.osgeo.org/geoserver:3.0-RC
-```
-
-Please share your success, feedback, questions, and any issues you encounter on the **user forum** [GeoServer 3.0-RC Release Candidate discourse thread](https://discourse.osgeo.org/t/geoserver-3-0-rc-release-candidate/153541). 
-
-### GeoServer Cloud 3.0.0-RC
-
-[GeoServer Cloud](https://geoserver.org/geoserver-cloud/) 3.0.0-RC has also been released alongside this candidate. Cloud-native deployments can now try out GeoServer 3 in microservices form, see the [v3.0.0-RC release notes](https://github.com/geoserver/geoserver-cloud/releases/tag/v3.0.0-RC) for details.
-
-To get started, follow the [Kubernetes quickstart](https://geoserver.org/geoserver-cloud/deploy/) and share your feedback so we can iron out any remaining issues before the final 3.0.0 release.
+See project [security policy](https://github.com/geoserver/geoserver/blob/main/SECURITY.md) for more information on how security vulnerabilities are managed.
 
 ## Welcome to GeoServer 3
 
-We are overjoyed to share this update with our community, this is the final stretch of a long road, a year of development, and a lot of planning and support to make it all happen.
-
-There will be more technical details in the final release announcement - but for now we wish to say thank you.
+We are overjoyed to share the release of GeoServer 3.0 with our community, this is the final stretch of a long road, a year of development, and a lot of planning and support to make it all happen. Thanks to all the organizations and individuals supporting GeoServer 3.
 
 <a href="/img/posts/3.0/welcome-global.png" target="_blank" rel="noopener">
   <img src="/img/posts/3.0/welcome-global.png" alt="GeoServer 3" class="screensnap"
@@ -60,7 +45,7 @@ There will be more technical details in the final release announcement - but for
 
 We have taken great pains to make the upgrade process seamless from GeoServer 2.28.x.
 
-1. Important: We have made no changes to the GeoServer Data Directory.
+1. Important: We have made **no changes** to the GeoServer Data Directory.
    
    Download and try GeoServer 3.0-RC today!
 
@@ -68,7 +53,8 @@ We have taken great pains to make the upgrade process seamless from GeoServer 2.
 
    * [WCS 1.0](https://docs.geoserver.org/latest/en/user/services/wcs/install/) and [WCS 1.1](https://docs.geoserver.org/latest/en/user/services/wcs/install/)
    * [World Image](https://docs.geoserver.org/latest/en/user/data/raster/arcgrid/#arcgrid_install) and [ArcGRID](https://docs.geoserver.org/latest/en/user/data/raster/arcgrid/#arcgrid_install) raster data sources.
-   
+   * [KML](https://docs.geoserver.org/main/en/user/extensions/kml/) output format
+    
    The pure Java `H2` database is no longer provided.
    
 3. The [log file location](https://docs.geoserver.org/latest/en/user/configuration/logging/#logging_location) setting
@@ -79,11 +65,21 @@ We have taken great pains to make the upgrade process seamless from GeoServer 2.
    
    Instructions are provided for how to clean up these now unused files.
    
-5. The new [OIDC](https://docs.geoserver.org/main/en/user/community/oidc/) plugin is available to take over the responsibilities of the previously available `Keycloak` and `OAuth2` plugins.
+5. The new [OIDC](https://docs.geoserver.org/main/en/user/extensions/oidc/) plugin is now available
+   as a full extension.
+   
+   This plugin takes over the responsibilities of the previously available `Keycloak` and `OAuth2` plugins.
+   For guidance on upgrading please see the detailed  [migration guide](https://docs.geoserver.org/main/en/user/extensions/oidc/migrating/).
 
 Please see the [upgrade instructions](https://docs.geoserver.org/latest/en/user/installation/upgrade3/) for details.
 
-### New Context-Driven User Experience
+### Thanks to the GeoServer 3 Sponsors
+
+GeoServer 3 would not exist without the organizations and individuals who supported the [GeoServer 3 crowdfunding campaign](/sponsor/gs3-crowdfunding). Their sponsorship made this work possible.
+
+{% include gs3-sponsors.html %}
+
+## New Context-Driven User Experience
 
 GeoServer 3 features a new "context-driven" user experience, which we really hope you enjoy.
 
@@ -141,8 +137,6 @@ GeoServer now provides a responsive-design theme:
     <img src="/img/posts/3.0/form-two-column.png" alt="Responsive Theme: Form two-column layerout" class="screensnap"
      style="max-width: 50%"/>
   </a>
-  
-Details coming soon to the developers guide!
 
 Thanks to Stefano Bovio (GeoSolutions) for leading this frequently requested improvement, the entire GeoServer 3 team for implementing and checking, and testers at AfriGIS and GeoCat for verifying and updating screenshots.
 
@@ -156,7 +150,7 @@ A new full-screen layer preview is provided using the latest OpenLayers library.
 
 Thanks to Stefano Bovio (GeoSolutions) for the welcome improvement.
 
-### Updated Environment
+## Updated Environment
 
 GeoServer 3 is overjoyed to support Tomcat 11.0.x and Jetty 12.1 application servers after completing our transition to Spring Framework 7 and Jakarta EE Servlet API 6.1.
 
@@ -177,18 +171,17 @@ For more information see [container considerations](https://docs.geoserver.org/l
 
 Thanks to the entire GeoServer 3 team and [crowdfunding campaign](/sponsor/gs3-crowdfunding) for this major accomplishment, representing the completion of Milestone 3.
 
-### New OAuth2 OpenID Connect Security Integration
+## OAuth2 OpenID Connect Extension
+
+The new OAuth2 OpenID Connect Security Integration (OIDC) plugin is now an official extension.
 
 The transition to Spring Security 7 was one of the big tasks accomplished for GeoServer 3. This work includes the creation of a new `OIDC` plugin. The new plugin has taken over the responsibilities of previously available `Keycloak` and `OAuth2` plugins.
 
-* If you previously used `Keycloak`, there are setup instructions for [configuring with Keycloak](https://docs.geoserver.org/main/en/user/community/oidc/oauth2/keycloak/).
-* If you previously used an `OAuth2` integration, you can find individual setup instructions for [Google](https://docs.geoserver.org/main/en/user/community/oidc/oauth2/google/), [Azure](https://docs.geoserver.org/main/en/user/community/oidc/oauth2/azure/), and [GitHub](https://docs.geoserver.org/main/en/user/community/oidc/oauth2/azure/).
+For guidance on upgrading please see the detailed  [migration guide](https://docs.geoserver.org/main/en/user/extensions/oidc/migrating/).
 
-We are asking specifically for public testing during 3.0-RC timeframe allowing this module to be included as an extension for 3.0.0 release.
+Thanks to Alessio Fabiani and others for this important improvement. Special thanks to everyone who provided feedback and testing during the 3.0-RC timeframe, your success has allowing this module to graduate to full extension for 3.0.0 release.
 
-Thanks to Alessio Fabiani and others for this improvement. We are very much looking forward to having [OAuth2 OpenID Connect](https://docs.geoserver.org/main/en/user/community/oidc/) support included in GeoServer.
-
-### New Documentation
+## New Documentation
 
 The long-awaited transition to Markdown documentation has finally arrived. Welcome to our new [User Manual](https://docs.geoserver.org/latest/en/user/).  The older GeoServer 2.x documentation is available at [Docs Archive](https://docs-archive.geoserver.org/) or via the version switcher.  Please help out by fixing any remaining [small issues](https://docs.geoserver.org/latest/en/docguide/quickfix/) or log an issue for Peter to address.
 
@@ -198,33 +191,39 @@ The long-awaited transition to Markdown documentation has finally arrived. Welco
 
 Thanks to Peter Smythe (AfriGIS) and Jody Garnett (GeoCat) for working on this activity which ended up being an incredible amount of work.
 
-### Thanks to the GeoServer 3 Sponsors
+### Pending Community Modules
 
-GeoServer 3 would not exist without the organizations and individuals who supported the [GeoServer 3 crowdfunding campaign](/sponsor/gs3-crowdfunding). Their sponsorship made this work possible.
+THe documentation contains a new heading for [pending community modules](https://docs.geoserver.org/main/en/user/community/#pending-community-modules) that are seeking public use and support in order
+to graduate to an extension.
 
-{% include gs3-sponsors.html %}
+A pending community been declared ready for feedback by the development team responsible and is available for general download alongside each release. The user manual indicates what specific support is needed for the module to be ready for production as a full extension.
 
 ## Release notes
 
-New features:
+New Feature:
 
-* [GEOS-12063](https://osgeo-org.atlassian.net/browse/GEOS-12063) [GSIP-238] GeoServer 3 UI / UX Refresh
+* [GEOS-12063](https://osgeo-org.atlassian.net/browse/GEOS-12063) GSIP-238 - GeoServer 3 UI / UX Refresh
+* [GEOS-12132](https://osgeo-org.atlassian.net/browse/GEOS-12132) GSIP 239 ‐ Promote OIDC Community Module to Extension
 
-Improvements:
+Improvement:
 
+* [GEOS-11581](https://osgeo-org.atlassian.net/browse/GEOS-11581) Set up leaner attribute transformations when attribute customization is enabled
 * [GEOS-11886](https://osgeo-org.atlassian.net/browse/GEOS-11886) Sort entries in all .properties files alphabetically
 * [GEOS-12015](https://osgeo-org.atlassian.net/browse/GEOS-12015) Switch tests using H2 to GeoPackage
 * [GEOS-12023](https://osgeo-org.atlassian.net/browse/GEOS-12023) Improve developer logging during catalog resources loading and WMS capabilities requests
 * [GEOS-12024](https://osgeo-org.atlassian.net/browse/GEOS-12024) Add Git branch name in GEOSERVER_NODE_OPTS
+* [GEOS-12070](https://osgeo-org.atlassian.net/browse/GEOS-12070) REST Support for CRSs
 * [GEOS-12072](https://osgeo-org.atlassian.net/browse/GEOS-12072) Remove deprecated REST endpoint on the DataStoreFileController
 * [GEOS-12077](https://osgeo-org.atlassian.net/browse/GEOS-12077) Remove H2/DB based index and binary index from CoverageMultidim/NetCDF stores
 * [GEOS-12081](https://osgeo-org.atlassian.net/browse/GEOS-12081) Update MapML.js (<mapml-viewer> custom element suite) to v0.17.0
 * [GEOS-12082](https://osgeo-org.atlassian.net/browse/GEOS-12082) CoverageStore - quick fail for incorrect files
 * [GEOS-12083](https://osgeo-org.atlassian.net/browse/GEOS-12083) Skip brute force login delays when checking for default administrator password
+* [GEOS-12103](https://osgeo-org.atlassian.net/browse/GEOS-12103) Reduce contention in concurrent requests
 
-Bugs:
+Bug:
 
 * [GEOS-10509](https://osgeo-org.atlassian.net/browse/GEOS-10509) WFS Request fails when XML POST body is larger than 8kB
+* [GEOS-10877](https://osgeo-org.atlassian.net/browse/GEOS-10877) [B/R Community Module] Restore Tasklet always fails on resources validation
 * [GEOS-11903](https://osgeo-org.atlassian.net/browse/GEOS-11903) WPS does not respect raw response output selection when there are multiple outputs
 * [GEOS-11916](https://osgeo-org.atlassian.net/browse/GEOS-11916) Data directory migration performed on built-in default security configuration
 * [GEOS-11926](https://osgeo-org.atlassian.net/browse/GEOS-11926) ogcapi plugin makes WFS advertising an outputFormat which is actually unavailable
@@ -239,11 +238,17 @@ Bugs:
 * [GEOS-12073](https://osgeo-org.atlassian.net/browse/GEOS-12073) Remove log location configuration from Admin Console and REST API
 * [GEOS-12084](https://osgeo-org.atlassian.net/browse/GEOS-12084) TemplateController REST endpoints accept non-existent workspace, store, and resource names
 * [GEOS-12085](https://osgeo-org.atlassian.net/browse/GEOS-12085) LocalSettingsController does not validate workspace existence
+* [GEOS-12092](https://osgeo-org.atlassian.net/browse/GEOS-12092) DescribeFeatureType fails to render a single option restriction in JSON format
+* [GEOS-12112](https://osgeo-org.atlassian.net/browse/GEOS-12112) OIDC OAuth2 login principals should also expose GeoServer user properties
+* [GEOS-12114](https://osgeo-org.atlassian.net/browse/GEOS-12114) GeoServer fails to start on FIPS-enabled system due to unsupported SHA1PRNG SecureRandom
+* [GEOS-12115](https://osgeo-org.atlassian.net/browse/GEOS-12115) Jetty 12.1.9 is not parsing Windows working directory settings
+* [GEOS-12118](https://osgeo-org.atlassian.net/browse/GEOS-12118) ReprojectingFeatureCollection can fail with ClassCastException while inserting CompoundCurve via WFS-T
 
-Tasks:
+Task:
 
+* [GEOS-11941](https://osgeo-org.atlassian.net/browse/GEOS-11941) Clean up Java 17 javadoc warnings
 * [GEOS-11987](https://osgeo-org.atlassian.net/browse/GEOS-11987) ImageN 0.9.1 migration requires renaming of registryFile.jai to registryFile.imagen
-* [GEOS-12004](https://osgeo-org.atlassian.net/browse/GEOS-12004) Make WMS independent of WFS
+* [GEOS-12004](https://osgeo-org.atlassian.net/browse/GEOS-12004) Make WMS indepependent of WFS
 * [GEOS-12005](https://osgeo-org.atlassian.net/browse/GEOS-12005) Remove GeoServer H2 extension
 * [GEOS-12006](https://osgeo-org.atlassian.net/browse/GEOS-12006) GWC, removal of leftover H2 references
 * [GEOS-12011](https://osgeo-org.atlassian.net/browse/GEOS-12011) Move KML module to extension
@@ -254,16 +259,19 @@ Tasks:
 * [GEOS-12025](https://osgeo-org.atlassian.net/browse/GEOS-12025) Split WMS 1.1 and 1.3
 * [GEOS-12040](https://osgeo-org.atlassian.net/browse/GEOS-12040) Updating BouncyCatle libraries to LTS 2.73.10
 * [GEOS-12041](https://osgeo-org.atlassian.net/browse/GEOS-12041) Update Spring LDAP to 4.0.1
-* [GEOS-12071](https://osgeo-org.atlassian.net/browse/GEOS-12071) Remove the WPS remote module
 * [GEOS-12064](https://osgeo-org.atlassian.net/browse/GEOS-12064) CSS: add documentation for localized @title and @abstract metadata
+* [GEOS-12071](https://osgeo-org.atlassian.net/browse/GEOS-12071) Remove the WPS remote module
+* [GEOS-12110](https://osgeo-org.atlassian.net/browse/GEOS-12110) Make use of XMLUtils for better integration with GeoTools.getEntityResolver()
+* [GEOS-12136](https://osgeo-org.atlassian.net/browse/GEOS-12136) IOTestUtils.createRandomDirectory() replacing mkdir call to more recent java.nio.files API
+* [GEOS-12137](https://osgeo-org.atlassian.net/browse/GEOS-12137) Update OSHI from 6.8.2 to 7.3.0
 
-Sub-tasks:
+Sub-task:
 
 * [GEOS-12066](https://osgeo-org.atlassian.net/browse/GEOS-12066) Present keywords as a table
 * [GEOS-12067](https://osgeo-org.atlassian.net/browse/GEOS-12067) Add Full Screen OpenLayers 10.8.0 layer preview
 * [GEOS-12086](https://osgeo-org.atlassian.net/browse/GEOS-12086) Keyboard navigation for file browser
 
-For the complete list see [3.0-RC](https://github.com/geoserver/geoserver/releases/tag/3.0-RC) release notes. 
+For the complete list see [3.0.0](https://github.com/geoserver/geoserver/releases/tag/3.0.0) release notes. 
 
 ## Community Updates
 
@@ -289,15 +297,27 @@ Community module development:
 * [GEOS-12069](https://osgeo-org.atlassian.net/browse/GEOS-12069) Align the hazelcast version in hz-cluster to the rest of GeoServer
 * [GEOS-12074](https://osgeo-org.atlassian.net/browse/GEOS-12074) Remove activeMQ-broker community module
 * [GEOS-12089](https://osgeo-org.atlassian.net/browse/GEOS-12089) GWC sqlite community module breaks legend preview in style page
+* [GEOS-12098](https://osgeo-org.atlassian.net/browse/GEOS-12098) Rename JWT Header assembly so it is collected for nightly downloads
+* [GEOS-12101](https://osgeo-org.atlassian.net/browse/GEOS-12101) Workspace styles not persisted to disk after restore
+* [GEOS-12119](https://osgeo-org.atlassian.net/browse/GEOS-12119) Workspace-scoped OGC API Styles endpoint returns styles from other workspaces
+* [GEOS-12129](https://osgeo-org.atlassian.net/browse/GEOS-12129) Longitudinal profile positive altitude includes first elevation as ascent from zero
 
 Community modules are shared as source code to encourage collaboration. If a topic being explored is of interest to you, please contact the module developer to offer assistance. 
 
-# About GeoServer 3.0.x Series
+# About GeoServer 3.0 Series
 
-Additional information on the GeoServer 3.0.x series:
+Additional information on GeoServer 3.0 series:
 
-* [GeoServer 3.0.x User Manual](https://docs.geoserver.org/3.0.x/en/user/)
+* [GeoServer 3.0 User Manual](https://docs.geoserver.org/3.0.x/en/user/)
+* [GeoServer 3.0-RC, a crowdfunded success story]({% post_url 2026-04-21-geoserver-3-rc-crowdfunding-success %})* [GSIP-221](https://github.com/geoserver/geoserver/wiki/GSIP-221) MkDocs Migration
+* [GSIP-226](https://github.com/geoserver/geoserver/wiki/GSIP-226) GeoServer 3
+* [GSIP-233](https://github.com/geoserver/geoserver/wiki/GSIP-233) Community Pending Profile
+* [GSIP-236](https://github.com/geoserver/geoserver/wiki/GSIP-236) Lightening up the Core for GeoServer 3
+* [GSIP-238](https://github.com/geoserver/geoserver/wiki/GSIP-238) UI / UX Refresh
+* [GSIP 239](https://github.com/geoserver/geoserver/wiki/GSIP-239) Promote OIDC Community Module to Extension
 
 Release notes:
-( [3.0-RC](https://github.com/geoserver/geoserver/releases/tag/3.0-RC)
+( [3.0.0](https://github.com/geoserver/geoserver/releases/tag/3.0.0)
+| [3.0-RC](https://github.com/geoserver/geoserver/releases/tag/3.0-RC)
 ) 
+

--- a/_posts/2026-06-11-geoserver-3-0-0-released.md
+++ b/_posts/2026-06-11-geoserver-3-0-0-released.md
@@ -216,6 +216,7 @@ Improvement:
 
 * [GEOS-11581](https://osgeo-org.atlassian.net/browse/GEOS-11581) Set up leaner attribute transformations when attribute customization is enabled
 * [GEOS-11886](https://osgeo-org.atlassian.net/browse/GEOS-11886) Sort entries in all .properties files alphabetically
+* [GEOS-11918](https://osgeo-org.atlassian.net/browse/GEOS-11918) CVE-2025-52465 Arbitrary file write vulnerability in Master Password Dump Page
 * [GEOS-12015](https://osgeo-org.atlassian.net/browse/GEOS-12015) Switch tests using H2 to GeoPackage
 * [GEOS-12023](https://osgeo-org.atlassian.net/browse/GEOS-12023) Improve developer logging during catalog resources loading and WMS capabilities requests
 * [GEOS-12024](https://osgeo-org.atlassian.net/browse/GEOS-12024) Add Git branch name in GEOSERVER_NODE_OPTS
@@ -231,8 +232,10 @@ Bug:
 
 * [GEOS-10509](https://osgeo-org.atlassian.net/browse/GEOS-10509) WFS Request fails when XML POST body is larger than 8kB
 * [GEOS-10877](https://osgeo-org.atlassian.net/browse/GEOS-10877) [B/R Community Module] Restore Tasklet always fails on resources validation
+* [GEOS-11777](https://osgeo-org.atlassian.net/browse/GEOS-11777) CVE-2024-45747 Server-Side Template Injection (SSTI) vulnerability in processing FreeMarker templates
 * [GEOS-11903](https://osgeo-org.atlassian.net/browse/GEOS-11903) WPS does not respect raw response output selection when there are multiple outputs
 * [GEOS-11916](https://osgeo-org.atlassian.net/browse/GEOS-11916) Data directory migration performed on built-in default security configuration
+* [GEOS-11920](https://osgeo-org.atlassian.net/browse/GEOS-11920) CVE-2025-58175 Server-Side Request Forgery (SSRF) Vulnerability in XML entity resolution
 * [GEOS-11926](https://osgeo-org.atlassian.net/browse/GEOS-11926) ogcapi plugin makes WFS advertising an outputFormat which is actually unavailable
 * [GEOS-11930](https://osgeo-org.atlassian.net/browse/GEOS-11930) OGC-API extension breaks security REST API 
 * [GEOS-11942](https://osgeo-org.atlassian.net/browse/GEOS-11942) ImagePPIO does not run any longer
@@ -241,6 +244,7 @@ Bug:
 * [GEOS-11981](https://osgeo-org.atlassian.net/browse/GEOS-11981) POST /security/authproviders | 400: Unsupported className
 * [GEOS-11988](https://osgeo-org.atlassian.net/browse/GEOS-11988) Fix bug: preserve metaTilingThreads=0 in saneConfig()
 * [GEOS-11999](https://osgeo-org.atlassian.net/browse/GEOS-11999) The version of Jetty (12) no longer supports web.xml CORS configuration
+* [GEOS-12043](https://osgeo-org.atlassian.net/browse/GEOS-12043) CVE-2025-27511 JNDI Vulnerability in DB2 Store Connection
 * [GEOS-12065](https://osgeo-org.atlassian.net/browse/GEOS-12065) WMS Layer REST PUT always returns 500 due to Collections.emptySet() in getRemoteStyleInfos()
 * [GEOS-12073](https://osgeo-org.atlassian.net/browse/GEOS-12073) Remove log location configuration from Admin Console and REST API
 * [GEOS-12084](https://osgeo-org.atlassian.net/browse/GEOS-12084) TemplateController REST endpoints accept non-existent workspace, store, and resource names

--- a/bin/announcement.py
+++ b/bin/announcement.py
@@ -58,10 +58,17 @@ def jira_series_releases(version_number):
     if not release_information:
         raise ValueError(f'Version number {version_number} not found')
 
-    series_name = release_information['name'][0:4]
+#     release_name = release_information['name']
+#     base_version = release_name.split("-")[0]  # "3.0.0" or "2.28-SNAPSHOT"
+#     parts = base_version.split(".")           # ["3", "0", "0"] or ["2","28"]
+#     
+#     major = int(parts[0])  # 3
+#     minor = int(parts[1])  # 0
+    series_name = release_information['name'].rsplit('.', 1)[0]
+    
     release_versions = []
     for version_information in versions:
-        if ((version_information['name'][0:4] == series_name) and
+        if ((version_information['name'].rsplit('.', 1)[0]== series_name) and
                 version_information['name'] <= release_information['name']):
             release_versions.append(version_information)
 
@@ -393,7 +400,7 @@ def md_release_notes(release_version, project_issues, templates):
 
 
 def md_about(release_version, release_versions, templates):
-    series_name = release_version['name'][0:4]
+    series_name = release_version['name'].rsplit('.', 1)[0]
     try:
         template = templates.get_template('about' + series_name[0:1] + series_name[2:] + '.md')
     except jinja2.TemplateNotFound:
@@ -490,7 +497,11 @@ if __name__ == "__main__":
     author = git_user()
 
     release_versions = jira_series_releases(release)
-    release_version = release_versions[0]
+    if release_versions:
+        release_version = release_versions[0]
+    else:
+        release_version = None 
+
     # print(json.dumps(release_version, indent=2))
 
     project_issues = jira_project_issues(release_version)

--- a/bin/templates/about30.md
+++ b/bin/templates/about30.md
@@ -1,0 +1,13 @@
+{% extends 'about.md' %}
+
+{% block features %}
+* {% raw %}[GeoServer 3.0-RC, a crowdfunded success story]({% post_url 2026-04-21-geoserver-3-rc-crowdfunding-success %}){% endraw %}
+* [GSIP-221](https://github.com/geoserver/geoserver/wiki/GSIP-221) MkDocs Migration
+* [GSIP-226](https://github.com/geoserver/geoserver/wiki/GSIP-226) GeoServer 3
+* [GSIP-233](https://github.com/geoserver/geoserver/wiki/GSIP-233) Community Pending Profile
+* [GSIP-236](https://github.com/geoserver/geoserver/wiki/GSIP-236) Lightening up the Core for GeoServer 3
+* [GSIP-238](https://github.com/geoserver/geoserver/wiki/GSIP-238) UI / UX Refresh
+* [GSIP 239](https://github.com/geoserver/geoserver/wiki/GSIP-239) Promote OIDC Community Module to Extension
+{% endblock %}
+
+GeoServer is an [Open Source Geospatial Foundation](https://www.osgeo.org/projects/geoserver/) project supported by a mix of volunteer and [service provider](https://geoserver.org/support/) activity. We reply on [sponsorship](https://geoserver.org/sponsor/) to fund activities beyond the reach of individual contributors.

--- a/css/app.css
+++ b/css/app.css
@@ -90,7 +90,7 @@ section {
 }
 
 #map {
-  height:400px;
+  height:500px;
   border: 1px solid #eee;
 }
 

--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@ Designed for interoperability, it publishes data from any major spatial data sou
             <h4>Stable</h4>
             <ul>
               <li><a href="/release/stable">{{site.stable_version}}</a></li>
-              <li><a href="/release/{{site.stable_branch}}">{{site.stable_branch | slice: 0, 4}} Nightly</a></li>
+              <li><a href="/release/{{site.stable_branch}}">{{site.stable_branch | slice: 0, 3}} Nightly</a></li>
             </ul>
           </div>
           <div class="col-md-4 download-maintain">
@@ -136,9 +136,9 @@ Designed for interoperability, it publishes data from any major spatial data sou
               <li id="download_dev_version"><a href="/release/dev">{{site.dev_version}}</a></li>
             {% endif %}
             {%- if site.dev_branch != 'main' -%}
-              <li><a href="/release/{{site.dev_branch}}">{{site.dev_branch | slice: 0, 4}} Nightly</a></li>
+              <li><a href="/release/{{site.dev_branch}}">{{site.dev_branch | slice: 0, 3}} Nightly</a></li>
             {% endif %}
-              <li><a href="/release/main">{{site.main_series | slice: 0, 4}} Nightly</a></li>
+              <li><a href="/release/main">{{site.main_series | slice: 0, 3}} Nightly</a></li>
             </ul>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -92,23 +92,6 @@ Designed for interoperability, it publishes data from any major spatial data sou
 <section id="">
   <div class="row">
     <div class="col-md-6">
-      <div id="gs3">
-        <h2><a href="/sponsor/gs3-crowdfunding">GeoServer 3 Crowdfunding</a></h2>
-        <div class="row">
-          <div class="col-md-6">
-          Consortium of Camptocamp, GeoSolutions and GeoCat have responded to our roadmap challenge
-          with a bold <a href="/sponsor/gs3-crowdfunding">GeoServer 3 Crowdfunding</a>.
-          Express interest or pledge support using <a href="mailto:gs3-funding@googlegroups.com">email</a> or <a href="https://forms.gle/EFML8NSJSCtzjWUY6">form</a>.
-          <!-- Technical details covered by <a href="https://docs.google.com/document/d/1iCqob2R5Zcs9liODq2UGGiOUQhFWQJrjZCJxBVUP5Q4/edit?usp=sharing">milestones and deliverables</a>. -->
-          </div>
-          <div class="col-md-6">
-            <a href="behind%20the%20scenes/2024/09/10/gs3">
-              <img class="guage" src="/img/posts/2.26/gs3-amount.png"
-                   alt="GeoServer 3 crowdfunding status (EUR)" loading="lazy" />
-            </a>
-          </div>
-        </div>
-      </div>
       <div id="map" class="map"></div>
     </div>
     <div class="col-md-6">
@@ -145,7 +128,7 @@ Designed for interoperability, it publishes data from any major spatial data sou
       </div>
       <div id="news">
         <h2><a href="blog/index.html" target="_blank">News</a></h2>
-          {% for i in (0..10) %}
+          {% for i in (0..5) %}
                 <h4><a href="{{ site.posts[i].url }}" >{{ site.posts[i].title }}</a> {{ site.posts[i].date | date: "%b %-d, %Y" }}{% if site.posts[i].author %} • {{ site.posts[i].author }}{% endif %}{% if site.posts[i].meta %} • {{ site.posts[i].meta }}{% endif %}</h4>
           {% endfor %}
       </div>
@@ -270,6 +253,13 @@ Designed for interoperability, it publishes data from any major spatial data sou
       <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=4XZ76BZMEWZ24&source=url">
         <img src="img/btn_donateCC_LG.gif" width="147" height="47"/>
       </a>
+    </div>
+    <div class="col-md-6" id="gs3">
+      <h4>GeoServer 3 Crowdfunding</h4>
+       <p class="text-left">
+         Consortium of Camptocamp, GeoSolutions and GeoCat responded to the project's Spring Framework 5
+         roadmap challenge with a successful <a href="/sponsor/gs3-crowdfunding">GeoServer 3 Crowdfunding</a>.
+       </p>
     </div>
   </div>
 </section>

--- a/sponsor/gs3-crowdfunding.md
+++ b/sponsor/gs3-crowdfunding.md
@@ -57,7 +57,9 @@ Project updates:
 * [Project Plan](https://docs.google.com/document/d/1EmI1kDsqeoxB9GANiiaZy56RY0pWbl6GqD4fq8EJ4oo/edit?tab=t.0)
 * [GSIP-226 GeoServer 3](https://github.com/geoserver/geoserver/wiki/GSIP-226)
 * [GeoServer 3 Sprint Update]({% post_url 2025-11-05-gs3-update %})
+* [GeoServer 3.0-RC, a crowdfunded success story]({% post_url 2026-04-21-geoserver-3-rc-crowdfunding-success %})
 * [GeoServer GeoServer 3 First public release date]({% post_url 2026-02-17-gs3-first-public-release-date %})
+* [GeoServer 3 is here, from crowdfunding to release]({% post_url 2026-06-11-geoserver-3-0-0-here-crowdfunding %}).
 
 ### Crowdfunding structure
 

--- a/sponsor/index.html
+++ b/sponsor/index.html
@@ -67,9 +67,8 @@ id: sponsorship
     <h4>GeoServer 3 Crowdfunding</h4>
     <p>
        Consortium of Camptocamp, GeoSolutions and GeoCat have responded to our
-       <a href="{% post_url 2024-01-03-roadmap%}">roadmap challenge</a> with a bold
+       <a href="{% post_url 2024-01-03-roadmap%}">roadmap challenge</a> with a successful
        <a href="/sponsor/gs3-crowdfunding">GeoServer 3 Crowdfunding</a>.
-       Express interest or pledge support using <a href="gs3-funding@googlegroups.com">email</a> or <a href="https://forms.gle/EFML8NSJSCtzjWUY6">form</a>.
     </p>
     
 {% include gs3-sponsors.html %}


### PR DESCRIPTION
Some changes were needed to:
- [x] Jekyll layout and _plugin/release.rb processing for new version numbers
- [x] bin/anouncement.py to work with new version numbers

This can go out as is, but I noticed a couple of things:

* When linking to OIDC for graduation to extension, I note it is still listed as community pending in the docs (and a broken link)
