### PR TITLE
August 2026 Releases

### DIFF
--- a/_posts/2026-02-18-geoserver-2-27-5-released.md
+++ b/_posts/2026-02-18-geoserver-2-27-5-released.md
@@ -39,9 +39,6 @@ Improvement:
 * [GEOS-12033](https://osgeo-org.atlassian.net/browse/GEOS-12033) Allow to configure custom CRS authorities and transformations
 * [GEOS-12037](https://osgeo-org.atlassian.net/browse/GEOS-12037) Support Metatiling on MapBox Vectortiles
 
-Task:
-
-
 For the complete list see [2.27.5](https://github.com/geoserver/geoserver/releases/tag/2.27.5) release notes. 
 
 # About GeoServer 2.27 Series

--- a/_posts/2026-08-14-geoserver-2-27-6-released.md
+++ b/_posts/2026-08-14-geoserver-2-27-6-released.md
@@ -1,0 +1,89 @@
+---
+author: Jody Garnett
+date: 2026-08-14
+layout: post
+title: GeoServer 2.27.6 Release
+categories:
+- Announcements
+- Vulnerability
+tags:
+- Release
+release: release_227
+version: 2.27.6
+jira_version: 17835
+--- 
+
+GeoServer [2.27.6](/release/2.27.6/) release is now available
+with downloads
+([bin](https://sourceforge.net/projects/geoserver/files/GeoServer/2.27.6/geoserver-2.27.6-bin.zip/download),
+[war](https://sourceforge.net/projects/geoserver/files/GeoServer/2.27.6/geoserver-2.27.6-war.zip/download),
+[windows](https://sourceforge.net/projects/geoserver/files/GeoServer/2.27.6/GeoServer-2.27.6-winsetup.exe/download)), along with 
+[docs](https://sourceforge.net/projects/geoserver/files/GeoServer/2.27.6/geoserver-2.27.6-htmldoc.zip/download) and
+[extensions](https://sourceforge.net/projects/geoserver/files/GeoServer/2.27.6/extensions/).
+
+This series has previously reached end-of-life, with this release issued to address an urgent bug or security vulnerability. Please apply this update as a mitigation measure only, and plan to upgrade to a stable or maintenance release of GeoServer.
+
+GeoServer 2.27.6 is made in conjunction with GeoTools 33.6. 
+
+Thanks to Andrea Aime (GeoSolutions) and Jody Garnett (GeoCat) for making this release.
+
+## Security Considerations
+
+This release addresses security vulnerabilities and is an urgent update for production systems.
+
+* [GHSA-mqjf-5f49-2fjh](https://github.com/geotools/geotools/security/advisories/GHSA-mqjf-5f49-2fjh) Unauthenticated SQL injection in the jsonArrayContains filter function against PostGIS layers (High)
+  
+  This releases includes the GeoTools 33.5 resolution of the above SQL Injection
+  vulnerability which affects PostGIS 12 and up.
+  Unfortunately our coordinated vulnerability disclosure policy was not followed in this case.
+  This post will be updated with an official CVE number when one is available.
+
+The use of the CVE system allows the GeoServer team to reach a wider audience than blog posts. 
+See project [security policy](https://github.com/geoserver/geoserver/blob/main/SECURITY.md) for more information on how security vulnerabilities are managed.
+
+## Release notes
+
+Improvement:
+
+* [GEOS-12080](https://osgeo-org.atlassian.net/browse/GEOS-12080) style edit: check image loads
+* [GEOS-12082](https://osgeo-org.atlassian.net/browse/GEOS-12082) CoverageStore - quick fail for incorrect files
+* [GEOS-12095](https://osgeo-org.atlassian.net/browse/GEOS-12095) LDAP: conversion from group-member-username to user-search username
+
+Task:
+
+
+For the complete list see [2.27.6](https://github.com/geoserver/geoserver/releases/tag/2.27.6) release notes. 
+
+## Community Updates
+
+Community module development:
+
+* [GEOS-12098](https://osgeo-org.atlassian.net/browse/GEOS-12098) Rename JWT Header assembly so it is collected for nightly downloads
+* [GEOS-12101](https://osgeo-org.atlassian.net/browse/GEOS-12101) Workspace styles not persisted to disk after restore
+* [GEOS-12129](https://osgeo-org.atlassian.net/browse/GEOS-12129) Longitudinal profile positive altitude includes first elevation as ascent from zero
+
+Community modules are shared as source code to encourage collaboration. If a topic being explored is of interest to you, please contact the module developer to offer assistance. 
+
+# About GeoServer 2.27 Series
+
+Additional information on GeoServer 2.27 series:
+
+* [GeoServer 2.27 User Manual](https://docs.geoserver.org/2.27.x/en/user/)
+* [CITE Certification achieved]({% post_url 2025-07-16-cite-certification %}) 
+* [GeoServer 2025 Q2 Developer Update]({% post_url 2025-05-13-developer-update %}) 
+* [GeoServer 2025 Roadmap]({% post_url 2025-01-13-roadmap %}) 
+* [Content-Security-Policy Headers](https://github.com/geoserver/geoserver/wiki/GSIP-227)
+* [OGCAPI Features Extension](https://github.com/geoserver/geoserver/wiki/GSIP-230)
+* [File system access isolation](https://github.com/geoserver/geoserver/wiki/GSIP-229)
+* [Promote data dir catalog loader to core](https://github.com/geoserver/geoserver/wiki/GSIP-231)
+
+Release notes:
+( [2.27.6](https://github.com/geoserver/geoserver/releases/tag/2.27.6)
+| [2.27.5](https://github.com/geoserver/geoserver/releases/tag/2.27.5)
+| [2.27.4](https://github.com/geoserver/geoserver/releases/tag/2.27.4)
+| [2.27.3](https://github.com/geoserver/geoserver/releases/tag/2.27.3)
+| [2.27.2](https://github.com/geoserver/geoserver/releases/tag/2.27.2)
+| [2.27.1](https://github.com/geoserver/geoserver/releases/tag/2.27.1)
+| [2.27.0](https://github.com/geoserver/geoserver/releases/tag/2.27.0)
+) 
+

--- a/_posts/2026-08-14-geoserver-2-28-5-released.md
+++ b/_posts/2026-08-14-geoserver-2-28-5-released.md
@@ -1,0 +1,100 @@
+---
+author: Jody Garnett
+date: 2026-08-14
+layout: post
+title: GeoServer 2.28.5 Release
+categories:
+- Announcements
+- Vulnerability
+tags:
+- Release
+release: release_228
+version: 2.28.5
+jira_version: 18034
+--- 
+
+GeoServer [2.28.5](/release/2.28.5/) release is now available
+with downloads
+([bin](https://sourceforge.net/projects/geoserver/files/GeoServer/2.28.5/geoserver-2.28.5-bin.zip/download),
+[war](https://sourceforge.net/projects/geoserver/files/GeoServer/2.28.5/geoserver-2.28.5-war.zip/download),
+[windows](https://sourceforge.net/projects/geoserver/files/GeoServer/2.28.5/GeoServer-2.28.5-winsetup.exe/download)), along with 
+[docs](https://sourceforge.net/projects/geoserver/files/GeoServer/2.28.5/geoserver-2.28.5-htmldoc.zip/download) and
+[extensions](https://sourceforge.net/projects/geoserver/files/GeoServer/2.28.5/extensions/).
+
+This is a maintenance release of GeoServer providing existing installations with minor updates and bug fixes.
+GeoServer 2.28.5 is made in conjunction with GeoTools 34.5, and GeoWebCache 1.28.5. 
+
+Thanks to Andrea Aime (GeoSolutions) and Jody Garnett (GeoCat) for making this release. 
+
+## Security Considerations
+
+This release addresses security vulnerabilities and is an urgent update for production systems.
+
+* [GHSA-mqjf-5f49-2fjh](https://github.com/geotools/geotools/security/advisories/GHSA-mqjf-5f49-2fjh) Unauthenticated SQL injection in the jsonArrayContains filter function against PostGIS layers (High)
+  
+  This releases includes the GeoTools 35.1 resolution of the above SQL Injection
+  vulnerability which affects PostGIS 12 and up.
+  Unfortunately our coordinated vulnerability disclosure policy was not followed in this case.
+  This post will be updated with an official CVE number when one is available.
+
+The use of the CVE system allows the GeoServer team to reach a wider audience than blog posts. 
+See project [security policy](https://github.com/geoserver/geoserver/blob/main/SECURITY.md) for more information on how security vulnerabilities are managed.
+
+## Release notes
+
+Improvement:
+
+* [GEOS-12080](https://osgeo-org.atlassian.net/browse/GEOS-12080) style edit: check image loads
+* [GEOS-12082](https://osgeo-org.atlassian.net/browse/GEOS-12082) CoverageStore - quick fail for incorrect files
+* [GEOS-12095](https://osgeo-org.atlassian.net/browse/GEOS-12095) LDAP: conversion from group-member-username to user-search username
+* [GEOS-12140](https://osgeo-org.atlassian.net/browse/GEOS-12140) Improve CoverageAccessLimits's RasterFilter masking on SecureGridCoverage2DReader reading
+* [GEOS-12141](https://osgeo-org.atlassian.net/browse/GEOS-12141) WMS nearest match machinery can issue queries that are guaranteed to return an empty result
+* [GEOS-12151](https://osgeo-org.atlassian.net/browse/GEOS-12151) Allow caching small images used by ImageMosaic in memory
+
+Bug:
+
+* [GEOS-11373](https://osgeo-org.atlassian.net/browse/GEOS-11373) Geometry type mismatch in WFS 1.1.0
+* [GEOS-11571](https://osgeo-org.atlassian.net/browse/GEOS-11571) The geoserver-2.26.0-printing-plugin is missing some dependend libraries
+* [GEOS-12138](https://osgeo-org.atlassian.net/browse/GEOS-12138) Improve DescribeDomains expandLimit validation
+* [GEOS-12145](https://osgeo-org.atlassian.net/browse/GEOS-12145) Missing spatial filter in `GeoFenceAccessManager` SQL query when only CLIP is applied
+* [GEOS-12146](https://osgeo-org.atlassian.net/browse/GEOS-12146) Wrong CRS axis order used in `SecuredFeatureSource` when clipping features for WFS 2.0.0 requests
+* [GEOS-12149](https://osgeo-org.atlassian.net/browse/GEOS-12149) GeoServer WMTS capabilities put query parameters in the wrong place in generated URLs
+* [GEOS-12165](https://osgeo-org.atlassian.net/browse/GEOS-12165) GeoServer does not start when fileLockProvider is set: lock wait times out
+
+Task:
+
+* [GEOS-12137](https://osgeo-org.atlassian.net/browse/GEOS-12137) Update OSHI from 6.8.2 to 7.3.0
+* [GEOS-12148](https://osgeo-org.atlassian.net/browse/GEOS-12148) Update GetFeatureInfo to list features (rather than as a table)
+
+Sub-task:
+
+* [GEOS-12153](https://osgeo-org.atlassian.net/browse/GEOS-12153) Include description in AttributeMap
+
+For the complete list see [2.28.5](https://github.com/geoserver/geoserver/releases/tag/2.28.5) release notes. 
+
+## Community Updates
+
+Community module development:
+
+* [GEOS-12129](https://osgeo-org.atlassian.net/browse/GEOS-12129) Longitudinal profile positive altitude includes first elevation as ascent from zero
+* [GEOS-12173](https://osgeo-org.atlassian.net/browse/GEOS-12173) Remove the REST module profile from community modules as the module does not exist here
+
+Community modules are shared as source code to encourage collaboration. If a topic being explored is of interest to you, please contact the module developer to offer assistance. 
+
+# About GeoServer 2.28 Series
+
+Additional information on GeoServer 2.28 series:
+
+* [GeoServer 2.28 User Manual](https://docs.geoserver.org/2.28.x/en/user/)
+* [GeoServer 2025 Q4 Developer Update]({% post_url 2025-10-14-developer-update %})
+* [GSIP-234](https://github.com/geoserver/geoserver/wiki/GSIP-234) Advertise and Enforce Attribute Restrictions
+
+Release notes:
+( [2.28.5](https://github.com/geoserver/geoserver/releases/tag/2.28.5)
+| [2.28.4](https://github.com/geoserver/geoserver/releases/tag/2.28.4)
+| [2.28.3](https://github.com/geoserver/geoserver/releases/tag/2.28.3)
+| [2.28.2](https://github.com/geoserver/geoserver/releases/tag/2.28.2)
+| [2.28.1](https://github.com/geoserver/geoserver/releases/tag/2.28.1)
+| [2.28.0](https://github.com/geoserver/geoserver/releases/tag/2.28.0)
+) 
+

--- a/_posts/2026-08-14-geoserver-2-28-5-released.md
+++ b/_posts/2026-08-14-geoserver-2-28-5-released.md
@@ -32,7 +32,7 @@ This release addresses security vulnerabilities and is an urgent update for prod
 
 * [GHSA-mqjf-5f49-2fjh](https://github.com/geotools/geotools/security/advisories/GHSA-mqjf-5f49-2fjh) Unauthenticated SQL injection in the jsonArrayContains filter function against PostGIS layers (High)
   
-  This releases includes the GeoTools 35.1 resolution of the above SQL Injection
+  This releases includes the GeoTools 34.5 resolution of the above SQL Injection
   vulnerability which affects PostGIS 12 and up.
   Unfortunately our coordinated vulnerability disclosure policy was not followed in this case.
   This post will be updated with an official CVE number when one is available.

--- a/_posts/2026-08-14-geoserver-3-0-1-released.md
+++ b/_posts/2026-08-14-geoserver-3-0-1-released.md
@@ -1,6 +1,6 @@
 ---
 author: Jody Garnett
-date: 2026-08-18
+date: 2026-08-14
 layout: post
 title: GeoServer 3.0.1 Release
 categories:

--- a/_posts/2026-08-18-geoserver-3-0-1-released.md
+++ b/_posts/2026-08-18-geoserver-3-0-1-released.md
@@ -1,0 +1,99 @@
+---
+author: Jody Garnett
+date: 2026-08-18
+layout: post
+title: GeoServer 3.0.1 Release
+categories:
+- Announcements
+- Vulnerability
+tags:
+- Release
+release: release_30.
+version: 3.0.1
+jira_version: 18069
+--- 
+
+GeoServer [3.0.1](/release/3.0.1/) release is now available
+with downloads
+([bin](https://sourceforge.net/projects/geoserver/files/GeoServer/3.0.1/geoserver-3.0.1-bin.zip/download),
+[war](https://sourceforge.net/projects/geoserver/files/GeoServer/3.0.1/geoserver-3.0.1-war.zip/download),
+[windows](https://sourceforge.net/projects/geoserver/files/GeoServer/3.0.1/GeoServer-3.0.1-winsetup.exe/download)), along with 
+[docs](https://sourceforge.net/projects/geoserver/files/GeoServer/3.0.1/geoserver-3.0.1-htmldoc.zip/download) and
+[extensions](https://sourceforge.net/projects/geoserver/files/GeoServer/3.0.1/extensions/).
+
+This is a stable release of GeoServer recommended for production use.
+GeoServer 3.0.1 is made in conjunction with GeoTools 35.1, and GeoWebCache 2.0.1. 
+
+Thanks to Andrea Aime (GeoSolutions) and Jody Garnett (GeoCat) for making this release. 
+
+## Security Considerations
+
+This release addresses security vulnerabilities and is an urgent update for production systems.
+
+* [GHSA-mqjf-5f49-2fjh](https://github.com/geotools/geotools/security/advisories/GHSA-mqjf-5f49-2fjh) Unauthenticated SQL injection in the jsonArrayContains filter function against PostGIS layers (High)
+  
+  This releases includes the GeoTools 35.1 resolution of the above SQL Injection
+  vulnerability which affects PostGIS 12 and up.
+  Unfortunately our coordinated vulnerability disclosure policy was not followed in this case.
+  This post will be updated with an official CVE number when one is available.
+
+The use of the CVE system allows the GeoServer team to reach a wider audience than blog posts. 
+See project [security policy](https://github.com/geoserver/geoserver/blob/main/SECURITY.md) for more information on how security vulnerabilities are managed.
+
+## Release notes
+
+New Feature:
+
+* [GEOS-12158](https://osgeo-org.atlassian.net/browse/GEOS-12158) Keycloak Role Service for use alongside OIDC Extension
+
+Improvement:
+
+* [GEOS-12095](https://osgeo-org.atlassian.net/browse/GEOS-12095) LDAP: conversion from group-member-username to user-search username
+* [GEOS-12124](https://osgeo-org.atlassian.net/browse/GEOS-12124) Make GWC seeder thread pool sizes configurable via gwc-gs.xml and environment variables
+* [GEOS-12139](https://osgeo-org.atlassian.net/browse/GEOS-12139) GSIP 241 - GeoWebCache Security-Aware Tile Caching
+* [GEOS-12140](https://osgeo-org.atlassian.net/browse/GEOS-12140) Improve CoverageAccessLimits's RasterFilter masking on SecureGridCoverage2DReader reading
+* [GEOS-12141](https://osgeo-org.atlassian.net/browse/GEOS-12141) WMS nearest match machinery can issue queries that are guaranteed to return an empty result
+* [GEOS-12151](https://osgeo-org.atlassian.net/browse/GEOS-12151) Allow caching small images used by ImageMosaic in memory
+* [GEOS-12154](https://osgeo-org.atlassian.net/browse/GEOS-12154) Improve URL validation in SLD processing
+* [GEOS-12169](https://osgeo-org.atlassian.net/browse/GEOS-12169) Update MapML viewer to v0.18.0
+
+Bug:
+
+* [GEOS-11373](https://osgeo-org.atlassian.net/browse/GEOS-11373) Geometry type mismatch in WFS 1.1.0
+* [GEOS-12144](https://osgeo-org.atlassian.net/browse/GEOS-12144) "application/vnd.ogc.fg+json" output format fails when requesting non-geographical datasets
+* [GEOS-12145](https://osgeo-org.atlassian.net/browse/GEOS-12145) Missing spatial filter in `GeoFenceAccessManager` SQL query when only CLIP is applied
+* [GEOS-12146](https://osgeo-org.atlassian.net/browse/GEOS-12146) Wrong CRS axis order used in `SecuredFeatureSource` when clipping features for WFS 2.0.0 requests
+* [GEOS-12149](https://osgeo-org.atlassian.net/browse/GEOS-12149) GeoServer WMTS capabilities put query parameters in the wrong place in generated URLs
+* [GEOS-12165](https://osgeo-org.atlassian.net/browse/GEOS-12165) GeoServer does not start when fileLockProvider is set: lock wait times out
+
+Sub-task:
+
+
+For the complete list see [3.0.1](https://github.com/geoserver/geoserver/releases/tag/3.0.1) release notes. 
+
+## Community Updates
+
+Community module development:
+
+* [GEOS-12173](https://osgeo-org.atlassian.net/browse/GEOS-12173) Remove the REST module profile from community modules as the module does not exist here
+
+Community modules are shared as source code to encourage collaboration. If a topic being explored is of interest to you, please contact the module developer to offer assistance. 
+
+# About GeoServer 3.0 Series
+
+Additional information on GeoServer 3.0 series:
+
+* [GeoServer 3.0 User Manual](https://docs.geoserver.org/3.0.x/en/user/)
+* [GeoServer 3.0-RC, a crowdfunded success story]({% post_url 2026-04-21-geoserver-3-rc-crowdfunding-success %})
+* [GSIP-221](https://github.com/geoserver/geoserver/wiki/GSIP-221) MkDocs Migration
+* [GSIP-226](https://github.com/geoserver/geoserver/wiki/GSIP-226) GeoServer 3
+* [GSIP-233](https://github.com/geoserver/geoserver/wiki/GSIP-233) Community Pending Profile
+* [GSIP-236](https://github.com/geoserver/geoserver/wiki/GSIP-236) Lightening up the Core for GeoServer 3
+* [GSIP-238](https://github.com/geoserver/geoserver/wiki/GSIP-238) UI / UX Refresh
+* [GSIP 239](https://github.com/geoserver/geoserver/wiki/GSIP-239) Promote OIDC Community Module to Extension
+
+Release notes:
+( [3.0.1](https://github.com/geoserver/geoserver/releases/tag/3.0.1)
+| [3.0.0](https://github.com/geoserver/geoserver/releases/tag/3.0.0)
+) 
+

--- a/bin/templates/about228.md
+++ b/bin/templates/about228.md
@@ -1,8 +1,8 @@
 {% extends 'about.md' %}
 
 {% block features %}
-* {% raw %}[GeoServer 2025 Q4 Developer Update]({% post_url 2025-10-14-developer-update %}){% endraw %}
-* [Advertise and Enforce Attribute Restrictions](https://github.com/geoserver/geoserver/wiki/GSIP-234)
+* {% raw %}[GeoServer 2025 Q4 Developer Update]({% post_url 2025-10-14-developer-update %}){% endraw %} 
+* [GSIP-234](https://github.com/geoserver/geoserver/wiki/GSIP-234) Advertise and Enforce Attribute Restrictions
 {% endblock %}
 
 GeoServer is an [Open Source Geospatial Foundation](https://www.osgeo.org/projects/geoserver/) project supported by a mix of volunteer and [service provider](https://geoserver.org/support/) activity. We reply on [sponsorship](https://geoserver.org/sponsor/) to fund activities beyond the reach of individual contributors.


### PR DESCRIPTION
Due to an active vulnerability we are issuing releases of:

* [x] GeoServer 3.0.1
* [x] GeoServer 2.28.5
* [x] GeoServer 2.27.6

This report will include the disclosure of:

* https://github.com/geotools/geotools/security/advisories/GHSA-mqjf-5f49-2fjh