### PR TITLE
Updates posts with CVE-2026-7690

### DIFF
--- a/_posts/2026-08-14-geoserver-2-27-6-released.md
+++ b/_posts/2026-08-14-geoserver-2-27-6-released.md
@@ -31,14 +31,13 @@ Thanks to Andrea Aime (GeoSolutions) and Jody Garnett (GeoCat) for making this r
 
 This release addresses security vulnerabilities and is an urgent update for production systems.
 
-* [GHSA-mqjf-5f49-2fjh](https://github.com/geotools/geotools/security/advisories/GHSA-mqjf-5f49-2fjh) Unauthenticated SQL injection in the `jsonArrayContains` filter function against PostGIS layers (High)
+* [CVE-2026-76904](https://github.com/geoserver/geoserver/security/advisories/GHSA-jvpx-6qxg-whgc) Unauthenticated PostGIS SQL injection in the jsonArrayContains filter function (Critical)
   
-  This releases includes the GeoTools 35.1 resolution of the above SQL Injection
+  This releases addresses the GeoTools [CVE-2026-76904](https://github.com/geotools/geotools/security/advisories/GHSA-mqjf-5f49-2fjh) SQL Injection
   vulnerability that: requires a Text or JSON column; affects PostGIS 12 and up.
   
   We would like to thank those who reported the problem following our coordinated vulnerability disclosure
   policy; unfortunately the issue was subject to public disclosure prior to our intended release schedule.
-  This post will be updated with an official CVE number when one is available.
 
 The use of the CVE system allows the GeoServer team to reach a wider audience than blog posts. 
 See project [security policy](https://github.com/geoserver/geoserver/blob/main/SECURITY.md) for more information on how security vulnerabilities are managed.

--- a/_posts/2026-08-14-geoserver-2-28-5-released.md
+++ b/_posts/2026-08-14-geoserver-2-28-5-released.md
@@ -30,14 +30,13 @@ Thanks to Andrea Aime (GeoSolutions) and Jody Garnett (GeoCat) for making this r
 
 This release addresses security vulnerabilities and is an urgent update for production systems.
 
-* [GHSA-mqjf-5f49-2fjh](https://github.com/geotools/geotools/security/advisories/GHSA-mqjf-5f49-2fjh) Unauthenticated SQL injection in the `jsonArrayContains` filter function against PostGIS layers (High)
+* [CVE-2026-76904](https://github.com/geoserver/geoserver/security/advisories/GHSA-jvpx-6qxg-whgc) Unauthenticated PostGIS SQL injection in the jsonArrayContains filter function (Critical)
   
-  This releases includes the GeoTools 35.1 resolution of the above SQL Injection
+  This releases addresses the GeoTools [CVE-2026-76904](https://github.com/geotools/geotools/security/advisories/GHSA-mqjf-5f49-2fjh) SQL Injection
   vulnerability that: requires a Text or JSON column; affects PostGIS 12 and up.
   
   We would like to thank those who reported the problem following our coordinated vulnerability disclosure
   policy; unfortunately the issue was subject to public disclosure prior to our intended release schedule.
-  This post will be updated with an official CVE number when one is available.
 
 The use of the CVE system allows the GeoServer team to reach a wider audience than blog posts. 
 See project [security policy](https://github.com/geoserver/geoserver/blob/main/SECURITY.md) for more information on how security vulnerabilities are managed.

--- a/_posts/2026-08-14-geoserver-3-0-1-released.md
+++ b/_posts/2026-08-14-geoserver-3-0-1-released.md
@@ -30,14 +30,13 @@ Thanks to Andrea Aime (GeoSolutions) and Jody Garnett (GeoCat) for making this r
 
 This release addresses security vulnerabilities and is an urgent update for production systems.
 
-* [GHSA-mqjf-5f49-2fjh](https://github.com/geotools/geotools/security/advisories/GHSA-mqjf-5f49-2fjh) Unauthenticated SQL injection in the `jsonArrayContains` filter function against PostGIS layers (High)
+* [CVE-2026-76904](https://github.com/geoserver/geoserver/security/advisories/GHSA-jvpx-6qxg-whgc) Unauthenticated PostGIS SQL injection in the jsonArrayContains filter function (Critical)
   
-  This releases includes the GeoTools 35.1 resolution of the above SQL Injection
+  This releases addresses the GeoTools [CVE-2026-76904](https://github.com/geotools/geotools/security/advisories/GHSA-mqjf-5f49-2fjh) SQL Injection
   vulnerability that: requires a Text or JSON column; affects PostGIS 12 and up.
   
   We would like to thank those who reported the problem following our coordinated vulnerability disclosure
   policy; unfortunately the issue was subject to public disclosure prior to our intended release schedule.
-  This post will be updated with an official CVE number when one is available.
 
 The use of the CVE system allows the GeoServer team to reach a wider audience than blog posts. 
 See project [security policy](https://github.com/geoserver/geoserver/blob/main/SECURITY.md) for more information on how security vulnerabilities are managed.


### PR DESCRIPTION
This update should be scheudled for non-weekend, it contains no new information (just that the CVE information is now provided).

Please publish GeoServer report for [CVE-2026-76904](https://github.com/geoserver/geoserver/security/advisories/GHSA-jvpx-6qxg-whgc) at the same time (linked to from this post) as it documents how GeoServer is affected (ie specific version numbers).